### PR TITLE
Implement consistent dialog behavior

### DIFF
--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
@@ -36,6 +36,7 @@
             <th>Nombre</th>
             <th>Apellido</th>
             <th>Año Ingreso</th>
+            <th class="text-end">Acciones</th>
           </tr>
         </thead>
         <tbody>
@@ -49,6 +50,16 @@
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
             <td>{{ est.Anio_Ingreso }}</td>
+            <td class="text-end">
+              <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-info" (click)="abrirFormulario('ver')">
+                  <i class="bi bi-eye"></i>
+                </button>
+                <button class="btn btn-outline-warning text-dark" (click)="abrirFormulario('editar')">
+                  <i class="bi bi-pencil-square"></i>
+                </button>
+              </div>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
@@ -52,7 +52,11 @@ export class DialogEstudiantesComponent implements OnInit {
   }
 
   abrirFormulario(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogFormEstudianteComponent, { centered: true });
+    const modalRef = this.modalService.open(DialogFormEstudianteComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
     modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionado;
 

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -7,10 +7,10 @@
         <button class="btn btn-success me-2" (click)="abrirDialog('crear')">
           <i class="bi bi-plus-circle me-1"></i> Nueva Asignatura
         </button>
-        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver')">
+        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver', seleccionada)">
           <i class="bi bi-eye me-1"></i> Ver
         </button>
-        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar')">
+        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar', seleccionada)">
           <i class="bi bi-pencil-square me-1"></i> Editar
         </button>
         <button class="btn btn-outline-primary ms-3" (click)="abrirDialogEstudiantes()">
@@ -38,6 +38,7 @@
                 <th>ID</th>
                 <th>Nombre</th>
                 <th>Profesor</th>
+                <th class="text-end">Acciones</th>
               </tr>
             </thead>
             <tbody>
@@ -50,6 +51,16 @@
                 <td>{{ asignatura.ID_Asignatura }}</td>
                 <td>{{ asignatura.Nombre }}</td>
                 <td>{{ asignatura.Profesor }}</td>
+                <td class="text-end">
+                  <div class="btn-group btn-group-sm">
+                    <button class="btn btn-outline-info" (click)="abrirDialog('ver', asignatura)">
+                      <i class="bi bi-eye"></i>
+                    </button>
+                    <button class="btn btn-outline-warning text-dark" (click)="abrirDialog('editar', asignatura)">
+                      <i class="bi bi-pencil-square"></i>
+                    </button>
+                  </div>
+                </td>
               </tr>
             </tbody>
           </table>

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -48,10 +48,14 @@ export class MainAsignaturasComponent implements OnInit {
     this.seleccionada = asignatura;
   }
 
-  abrirDialog(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogAsignaturaComponent, { centered: true });
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: any) {
+    const modalRef = this.modalService.open(DialogAsignaturaComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura ?? this.seleccionada;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -59,7 +63,12 @@ export class MainAsignaturasComponent implements OnInit {
   }
 
   abrirDialogEstudiantes() {
-    const modalRef = this.modalService.open(DialogEstudiantesComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogEstudiantesComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -68,7 +77,12 @@ export class MainAsignaturasComponent implements OnInit {
 
   abrirDialogInscripcion() {
     if (!this.seleccionada) return;
-    const modalRef = this.modalService.open(DialogInscripcionComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogInscripcionComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.asignatura = this.seleccionada;
 
     modalRef.result.then(res => {

--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
@@ -11,10 +11,10 @@
         <button class="btn btn-success me-2" (click)="abrirDialog('crear')">
           <i class="bi bi-plus-circle me-1"></i> Nueva Carrera
         </button>
-        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver')">
+        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver', seleccionada)">
           <i class="bi bi-eye me-1"></i> Ver
         </button>
-        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar')">
+        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar', seleccionada)">
           <i class="bi bi-pencil-square me-1"></i> Editar
         </button>
       </div>
@@ -31,6 +31,7 @@
             <tr>
               <th>Nombre</th>
               <th>Jefe de Carrera</th>
+              <th class="text-end">Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -42,6 +43,16 @@
             >
               <td>{{ carrera.Nombre }}</td>
               <td>{{ carrera.JefeCarrera }}</td>
+              <td class="text-end">
+                <div class="btn-group btn-group-sm">
+                  <button class="btn btn-outline-info" (click)="abrirDialog('ver', carrera)">
+                    <i class="bi bi-eye"></i>
+                  </button>
+                  <button class="btn btn-outline-warning text-dark" (click)="abrirDialog('editar', carrera)">
+                    <i class="bi bi-pencil-square"></i>
+                  </button>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
@@ -43,11 +43,15 @@ export class MainCarrerasComponent implements OnInit {
     this.seleccionada = carrera;
   }
 
-  abrirDialog(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogCarreraComponent, { centered: true });
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', carrera?: any) {
+    const modalRef = this.modalService.open(DialogCarreraComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
     modalRef.componentInstance.jefes = this.jefes;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : carrera ?? this.seleccionada;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarCarreras();

--- a/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
@@ -37,7 +37,12 @@ export class DialogEvaluacionesComponent implements OnInit {
   }
 
   abrirDialogCrearEvaluacion() {
-    const modalRef = this.modalService.open(DialogCrearEvaluacionComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogCrearEvaluacionComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.asignatura = this.asignatura;
 
     modalRef.result.then(res => {
@@ -46,7 +51,13 @@ export class DialogEvaluacionesComponent implements OnInit {
   }
 
   abrirDetalleEvaluacion(evaluacionID: number) {
-    const modalRef = this.modalService.open(MainEvaluacionDetalleComponent, { centered: true, size: 'xl', scrollable: true });
+    const modalRef = this.modalService.open(MainEvaluacionDetalleComponent, {
+      centered: true,
+      size: 'xl',
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.evaluacionID = evaluacionID;
     modalRef.componentInstance.asignaturaID = this.asignatura.ID_Asignatura;
 

--- a/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
+++ b/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
@@ -80,7 +80,9 @@ export class MainEvaluacionDetalleComponent implements OnInit {
     const modalRef = this.modalService.open(DialogRubricaEvaluacionComponent, {
       centered: true,
       size: 'xl',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;
@@ -110,7 +112,9 @@ export class MainEvaluacionDetalleComponent implements OnInit {
     const modalRef = this.modalService.open(DialogGruposEvaluacionComponent, {
       centered: true,
       size: 'lg',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;

--- a/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
+++ b/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
@@ -24,7 +24,9 @@ export class TarjetaGrupoComponent {
     const modalRef = this.modalService.open(DialogRubricaEvaluacionComponent, {
       centered: true,
       size: 'xl',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;

--- a/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.html
+++ b/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.html
@@ -29,6 +29,7 @@
               <th>Nombre</th>
               <th>Semestre</th>
               <th>Plan Académico</th>
+              <th class="text-end">Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -42,6 +43,16 @@
               <td>{{ a.Nombre }}</td>
               <td>{{ a.Semestre }}</td>
               <td>{{ a.Plan_Academico }}</td>
+              <td class="text-end">
+                <div class="btn-group btn-group-sm">
+                  <button class="btn btn-outline-info" (click)="seleccionar(a); verAsignatura()">
+                    <i class="bi bi-eye"></i>
+                  </button>
+                  <button class="btn btn-outline-dark" (click)="seleccionar(a); abrirEvaluaciones()">
+                    <i class="bi bi-ui-checks-grid"></i>
+                  </button>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.ts
+++ b/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.ts
@@ -53,7 +53,12 @@ export class MainAsignaturasProfesorComponent implements OnInit {
 
   abrirEvaluaciones() {
     if (!this.seleccionada) return;
-    const modalRef = this.modalService.open(DialogEvaluacionesComponent, { centered: true, size: 'xl' });
+    const modalRef = this.modalService.open(DialogEvaluacionesComponent, {
+      centered: true,
+      size: 'xl',
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.asignatura = this.seleccionada;
 
     modalRef.result.then(res => {


### PR DESCRIPTION
## Summary
- prevent accidental modal closure using `backdrop: 'static'` and `keyboard: false`
- add inline view/edit actions to carreras and asignaturas grids
- apply Bootstrap buttons in estudiante list
- ensure evaluaciones dialogs use the same modal options

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842705eb0c4832b8878b831707aa15e