### PR TITLE
Add backend start script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ ng serve
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 
+## Backend server
+
+To start the backend API, change into the `backend/` directory and run:
+
+```bash
+npm start
+```
+
 ## Code scaffolding
 
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add npm start script in backend/package.json
- add README instructions for starting backend

## Testing
- `npm test` *(fails: ng not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684270b7e028832b8ee42b5c4f53d11c