### PR TITLE
Use environment apiUrl for services

### DIFF
--- a/src/app/services/aplicacion.service.ts
+++ b/src/app/services/aplicacion.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AplicacionService {
-  private apiUrl = 'http://localhost:3000/api/aplicacion';
+  private apiUrl = `${environment.apiUrl}/api/aplicacion`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/asignatura.service.ts
+++ b/src/app/services/asignatura.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AsignaturaService {
-  private apiUrl = 'http://localhost:3000/api/asignatura';
+  private apiUrl = `${environment.apiUrl}/api/asignatura`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/carrera.service.ts
+++ b/src/app/services/carrera.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CarreraService {
-  private apiUrl = 'http://localhost:3000/api/carrera';
+  private apiUrl = `${environment.apiUrl}/api/carrera`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/competencia.service.ts
+++ b/src/app/services/competencia.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 export interface Competencia {
@@ -12,7 +13,7 @@ export interface Competencia {
   providedIn: 'root'
 })
 export class CompetenciaService {
-  private apiUrl = 'http://localhost:3000/api/competencia'; // Asegúrate que este sea tu prefijo correcto
+  private apiUrl = `${environment.apiUrl}/api/competencia`; // Asegúrate que este sea tu prefijo correcto
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/contenido.service.ts
+++ b/src/app/services/contenido.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ContenidoService {
-  private apiUrl = 'http://localhost:3000/api/contenido';
+  private apiUrl = `${environment.apiUrl}/api/contenido`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/estudiante.service.ts
+++ b/src/app/services/estudiante.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class EstudianteService {
-  private apiUrl = 'http://localhost:3000/api/estudiante';
+  private apiUrl = `${environment.apiUrl}/api/estudiante`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/evaluacion.service.ts
+++ b/src/app/services/evaluacion.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class EvaluacionService {
-  private apiUrl = 'http://localhost:3000/api/evaluacion';
+  private apiUrl = `${environment.apiUrl}/api/evaluacion`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/indicador.service.ts
+++ b/src/app/services/indicador.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class IndicadorService {
-  private apiUrl = 'http://localhost:3000/api/indicador';
+  private apiUrl = `${environment.apiUrl}/api/indicador`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/inscripcion.service.ts
+++ b/src/app/services/inscripcion.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class InscripcionService {
-  private apiUrl = 'http://localhost:3000/api/inscripcion';
+  private apiUrl = `${environment.apiUrl}/api/inscripcion`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/ra.service.ts
+++ b/src/app/services/ra.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RaService {
-  private apiUrl = 'http://localhost:3000/api/ra';
+  private apiUrl = `${environment.apiUrl}/api/ra`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/rol.service.ts
+++ b/src/app/services/rol.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RolService {
-  private apiUrl = 'http://localhost:3000/api/rol';
+  private apiUrl = `${environment.apiUrl}/api/rol`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/services/usuario.service.ts
+++ b/src/app/services/usuario.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UsuarioService {
-  private apiUrl = 'http://localhost:3000/api/usuario';
+  private apiUrl = `${environment.apiUrl}/api/usuario`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};
+

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000'
+};
+


### PR DESCRIPTION
## Summary
- add Angular environment files with `apiUrl`
- use `environment.apiUrl` instead of hardcoded URLs in services

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684270b8a15c832b85ab1ea36db35a37