### PR TITLE
UI tweaks across modules

### DIFF
--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
@@ -36,6 +36,7 @@
             <th>Nombre</th>
             <th>Apellido</th>
             <th>Año Ingreso</th>
+            <th class="text-end">Acciones</th>
           </tr>
         </thead>
         <tbody>
@@ -49,6 +50,16 @@
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
             <td>{{ est.Anio_Ingreso }}</td>
+            <td class="text-end">
+              <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-info" (click)="abrirFormulario('ver')">
+                  <i class="bi bi-eye"></i>
+                </button>
+                <button class="btn btn-outline-warning text-dark" (click)="abrirFormulario('editar')">
+                  <i class="bi bi-pencil-square"></i>
+                </button>
+              </div>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
@@ -52,7 +52,11 @@ export class DialogEstudiantesComponent implements OnInit {
   }
 
   abrirFormulario(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogFormEstudianteComponent, { centered: true });
+    const modalRef = this.modalService.open(DialogFormEstudianteComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
     modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionado;
 

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -7,10 +7,10 @@
         <button class="btn btn-success me-2" (click)="abrirDialog('crear')">
           <i class="bi bi-plus-circle me-1"></i> Nueva Asignatura
         </button>
-        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver')">
+        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver', seleccionada)">
           <i class="bi bi-eye me-1"></i> Ver
         </button>
-        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar')">
+        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar', seleccionada)">
           <i class="bi bi-pencil-square me-1"></i> Editar
         </button>
         <button class="btn btn-outline-primary ms-3" (click)="abrirDialogEstudiantes()">
@@ -38,6 +38,7 @@
                 <th>ID</th>
                 <th>Nombre</th>
                 <th>Profesor</th>
+                <th class="text-end">Acciones</th>
               </tr>
             </thead>
             <tbody>
@@ -50,6 +51,16 @@
                 <td>{{ asignatura.ID_Asignatura }}</td>
                 <td>{{ asignatura.Nombre }}</td>
                 <td>{{ asignatura.Profesor }}</td>
+                <td class="text-end">
+                  <div class="btn-group btn-group-sm">
+                    <button class="btn btn-outline-info" (click)="abrirDialog('ver', asignatura)">
+                      <i class="bi bi-eye"></i>
+                    </button>
+                    <button class="btn btn-outline-warning text-dark" (click)="abrirDialog('editar', asignatura)">
+                      <i class="bi bi-pencil-square"></i>
+                    </button>
+                  </div>
+                </td>
               </tr>
             </tbody>
           </table>

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -48,10 +48,14 @@ export class MainAsignaturasComponent implements OnInit {
     this.seleccionada = asignatura;
   }
 
-  abrirDialog(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogAsignaturaComponent, { centered: true });
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: any) {
+    const modalRef = this.modalService.open(DialogAsignaturaComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura ?? this.seleccionada;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -59,7 +63,12 @@ export class MainAsignaturasComponent implements OnInit {
   }
 
   abrirDialogEstudiantes() {
-    const modalRef = this.modalService.open(DialogEstudiantesComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogEstudiantesComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -68,7 +77,12 @@ export class MainAsignaturasComponent implements OnInit {
 
   abrirDialogInscripcion() {
     if (!this.seleccionada) return;
-    const modalRef = this.modalService.open(DialogInscripcionComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogInscripcionComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.asignatura = this.seleccionada;
 
     modalRef.result.then(res => {

--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
@@ -11,10 +11,10 @@
         <button class="btn btn-success me-2" (click)="abrirDialog('crear')">
           <i class="bi bi-plus-circle me-1"></i> Nueva Carrera
         </button>
-        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver')">
+        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="abrirDialog('ver', seleccionada)">
           <i class="bi bi-eye me-1"></i> Ver
         </button>
-        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar')">
+        <button class="btn btn-warning text-white" [disabled]="!seleccionada" (click)="abrirDialog('editar', seleccionada)">
           <i class="bi bi-pencil-square me-1"></i> Editar
         </button>
       </div>
@@ -31,6 +31,7 @@
             <tr>
               <th>Nombre</th>
               <th>Jefe de Carrera</th>
+              <th class="text-end">Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -42,6 +43,16 @@
             >
               <td>{{ carrera.Nombre }}</td>
               <td>{{ carrera.JefeCarrera }}</td>
+              <td class="text-end">
+                <div class="btn-group btn-group-sm">
+                  <button class="btn btn-outline-info" (click)="abrirDialog('ver', carrera)">
+                    <i class="bi bi-eye"></i>
+                  </button>
+                  <button class="btn btn-outline-warning text-dark" (click)="abrirDialog('editar', carrera)">
+                    <i class="bi bi-pencil-square"></i>
+                  </button>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
@@ -43,11 +43,15 @@ export class MainCarrerasComponent implements OnInit {
     this.seleccionada = carrera;
   }
 
-  abrirDialog(modo: 'crear' | 'ver' | 'editar') {
-    const modalRef = this.modalService.open(DialogCarreraComponent, { centered: true });
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', carrera?: any) {
+    const modalRef = this.modalService.open(DialogCarreraComponent, {
+      centered: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.modo = modo;
     modalRef.componentInstance.jefes = this.jefes;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : carrera ?? this.seleccionada;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarCarreras();

--- a/src/app/modules/profesor/evaluaciones/dialog-crear-evaluacion/dialog-crear-evaluacion/dialog-crear-evaluacion.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-crear-evaluacion/dialog-crear-evaluacion/dialog-crear-evaluacion.component.html
@@ -32,12 +32,11 @@
         type="checkbox"
         [value]="c.ID_Contenido"
         (change)="toggleContenido(c.ID_Contenido)"
-        [disabled]="contenidosUsados.includes(c.ID_Contenido) || bloqueado"
+        [disabled]="bloqueado"
         [checked]="seleccionados.includes(c.ID_Contenido)"
       />
-      <label class="form-check-label text-muted" [ngClass]="{ 'text-decoration-line-through': contenidosUsados.includes(c.ID_Contenido) }">
+      <label class="form-check-label">
         {{ c.Nucleo_Tematico }}
-        <span *ngIf="contenidosUsados.includes(c.ID_Contenido)" class="badge bg-secondary ms-2">Ya utilizado</span>
       </label>
     </div>
   </div>

--- a/src/app/modules/profesor/evaluaciones/dialog-crear-evaluacion/dialog-crear-evaluacion/dialog-crear-evaluacion.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-crear-evaluacion/dialog-crear-evaluacion/dialog-crear-evaluacion.component.ts
@@ -20,7 +20,6 @@ export class DialogCrearEvaluacionComponent implements OnInit {
   instancia = 1;
   contenidos: any[] = [];
   seleccionados: number[] = [];
-  contenidosUsados: number[] = [];
 
   mensajeError = '';
   mensajeExito = '';
@@ -38,12 +37,11 @@ export class DialogCrearEvaluacionComponent implements OnInit {
   }
 
   cargarContenidos() {
-    this.contenidoService.obtenerPorAsignatura(this.asignatura.ID_Asignatura).subscribe(data => {
-      this.contenidos = data;
-      this.evaluacionService.obtenerContenidosUsados(this.asignatura.ID_Asignatura).subscribe(usados => {
-        this.contenidosUsados = usados;
+    this.contenidoService
+      .obtenerPorAsignatura(this.asignatura.ID_Asignatura)
+      .subscribe((data) => {
+        this.contenidos = data;
       });
-    });
   }
 
   obtenerInstancia() {

--- a/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
@@ -37,7 +37,12 @@ export class DialogEvaluacionesComponent implements OnInit {
   }
 
   abrirDialogCrearEvaluacion() {
-    const modalRef = this.modalService.open(DialogCrearEvaluacionComponent, { centered: true, size: 'lg' });
+    const modalRef = this.modalService.open(DialogCrearEvaluacionComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.asignatura = this.asignatura;
 
     modalRef.result.then(res => {
@@ -46,7 +51,13 @@ export class DialogEvaluacionesComponent implements OnInit {
   }
 
   abrirDetalleEvaluacion(evaluacionID: number) {
-    const modalRef = this.modalService.open(MainEvaluacionDetalleComponent, { centered: true, size: 'xl', scrollable: true });
+    const modalRef = this.modalService.open(MainEvaluacionDetalleComponent, {
+      centered: true,
+      size: 'xl',
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
+    });
     modalRef.componentInstance.evaluacionID = evaluacionID;
     modalRef.componentInstance.asignaturaID = this.asignatura.ID_Asignatura;
 

--- a/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
+++ b/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
@@ -80,7 +80,9 @@ export class MainEvaluacionDetalleComponent implements OnInit {
     const modalRef = this.modalService.open(DialogRubricaEvaluacionComponent, {
       centered: true,
       size: 'xl',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;
@@ -110,7 +112,9 @@ export class MainEvaluacionDetalleComponent implements OnInit {
     const modalRef = this.modalService.open(DialogGruposEvaluacionComponent, {
       centered: true,
       size: 'lg',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;

--- a/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
+++ b/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
@@ -24,7 +24,9 @@ export class TarjetaGrupoComponent {
     const modalRef = this.modalService.open(DialogRubricaEvaluacionComponent, {
       centered: true,
       size: 'xl',
-      scrollable: true
+      scrollable: true,
+      backdrop: 'static',
+      keyboard: false
     });
 
     modalRef.componentInstance.evaluacionID = this.evaluacionID;

--- a/src/app/modules/rubricas/main-asignaturas-jefe/main-asignaturas-jefe.component.html
+++ b/src/app/modules/rubricas/main-asignaturas-jefe/main-asignaturas-jefe.component.html
@@ -2,49 +2,31 @@
   <app-sidebar [rol]="rolUsuario"></app-sidebar>
 
   <div class="flex-grow-1 p-4" style="background-color: #f4f6fa; min-height: 100vh;">
-    <!-- Header -->
-    <div class="d-flex justify-content-between align-items-start mb-4">
-      <div>
-        <button class="btn btn-info me-2 text-white" [disabled]="!seleccionada" (click)="verAsignatura()" aria-label="Ver Asignatura">
-          <i class="bi bi-eye me-1"></i> Ver
-        </button>
-        <button class="btn btn-outline-primary ms-3" [disabled]="!seleccionada" (click)="abrirContenidos()" aria-label="Abrir Contenidos">
-          <i class="bi bi-journals me-1"></i> Contenidos
-        </button>
-      </div>
-      <h3 class="fw-bold" style="color: #002F5D;">
-        <i class="bi bi-book-half me-2"></i>Asignaturas de la Carrera
-      </h3>
-    </div>
+    <h3 class="fw-bold mb-4" style="color: #002F5D;">
+      <i class="bi bi-book-half me-2"></i>Asignaturas de la Carrera
+    </h3>
 
-    <!-- Tabla de asignaturas -->
-    <div class="card shadow-sm border-0">
-      <div class="card-body p-0">
-        <table class="table table-hover mb-0">
-          <thead class="table-light">
-            <tr>
-              <th>ID</th>
-              <th>Nombre</th>
-              <th>Semestre</th>
-              <th>Plan Académico</th>
-              <th>Profesor</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              *ngFor="let a of asignaturas"
-              (click)="seleccionar(a)"
-              [class.table-active]="seleccionada?.ID_Asignatura === a.ID_Asignatura"
-              style="cursor: pointer;"
-            >
-              <td>{{ a.ID_Asignatura }}</td>
-              <td>{{ a.Nombre }}</td>
-              <td>{{ a.Semestre }}</td>
-              <td>{{ a.Plan_Academico }}</td>
-              <td>{{ a.Profesor }}</td>
-            </tr>
-          </tbody>
-        </table>
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+      <div class="col" *ngFor="let a of asignaturas">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title text-primary">{{ a.Nombre }}</h5>
+            <p class="card-text mb-2">
+              <strong>ID:</strong> {{ a.ID_Asignatura }}<br>
+              <strong>Semestre:</strong> {{ a.Semestre }}<br>
+              <strong>Plan:</strong> {{ a.Plan_Academico }}<br>
+              <strong>Profesor:</strong> {{ a.Profesor }}
+            </p>
+            <div class="mt-auto d-flex gap-2">
+              <button class="btn btn-outline-info btn-sm" (click)="verAsignatura(a)">
+                <i class="bi bi-eye"></i> Ver
+              </button>
+              <button class="btn btn-outline-primary btn-sm" (click)="abrirContenidos(a)">
+                <i class="bi bi-journals"></i> Contenidos
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/modules/rubricas/main-asignaturas-jefe/main-asignaturas-jefe.component.ts
+++ b/src/app/modules/rubricas/main-asignaturas-jefe/main-asignaturas-jefe.component.ts
@@ -16,7 +16,6 @@ import { DialogAsignaturaComponent } from '../../admin/asignaturas/dialog-asigna
 export class MainAsignaturasJefeComponent implements OnInit {
   rolUsuario = '';
   asignaturas: any[] = [];
-  seleccionada: any = null;
 
   constructor(
     private modalService: NgbModal,
@@ -32,46 +31,39 @@ export class MainAsignaturasJefeComponent implements OnInit {
     const rut = localStorage.getItem('rut');
     if (!rut) return;
 
-    this.asignaturaService.obtenerPorCarreraDelJefe(rut).subscribe(data => {
+    this.asignaturaService.obtenerPorCarreraDelJefe(rut).subscribe((data) => {
       this.asignaturas = data;
     });
   }
 
-  seleccionar(asignatura: any) {
-    this.seleccionada = asignatura;
+  verAsignatura(asignatura: any) {
+    const modalRef = this.modalService.open(DialogAsignaturaComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false,
+    });
+
+    modalRef.componentInstance.modo = 'ver';
+    modalRef.componentInstance.datos = asignatura;
   }
 
-verAsignatura() {
-  if (!this.seleccionada) return;
+  abrirContenidos(asignatura: any) {
+    const modalRef = this.modalService.open(DialogContenidoComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static', // ✅ evita cierre al hacer clic fuera
+      keyboard: false, // ✅ evita cierre con tecla Esc
+    });
 
-  const modalRef = this.modalService.open(DialogAsignaturaComponent, {
-    centered: true,
-    size: 'lg',
-    backdrop: 'static',
-    keyboard: false
-  });
+    modalRef.componentInstance.asignaturaID = asignatura.ID_Asignatura;
 
-  modalRef.componentInstance.modo = 'ver';
-  modalRef.componentInstance.datos = this.seleccionada;
-}
-
-
-abrirContenidos() {
-  if (!this.seleccionada) return;
-
-  const modalRef = this.modalService.open(DialogContenidoComponent, {
-    centered: true,
-    size: 'lg',
-    backdrop: 'static', // ✅ evita cierre al hacer clic fuera
-    keyboard: false      // ✅ evita cierre con tecla Esc
-  });
-
-  modalRef.componentInstance.asignaturaID = this.seleccionada.ID_Asignatura;
-
-  modalRef.result.then(res => {
-    if (res === 'actualizado') this.cargarAsignaturas();
-  }).catch(() => {});
-}
+    modalRef.result
+      .then((res) => {
+        if (res === 'actualizado') this.cargarAsignaturas();
+      })
+      .catch(() => {});
+  }
 
 
 }

--- a/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.html
+++ b/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.html
@@ -3,48 +3,30 @@
   <app-sidebar [rol]="rolUsuario"></app-sidebar>
 
   <div class="flex-grow-1 p-4" style="background-color: #f4f6fa; min-height: 100vh;">
-    <!-- Header -->
-    <div class="d-flex justify-content-between align-items-start mb-4">
-      <div class="d-flex flex-wrap gap-2">
-        <button class="btn btn-info text-white" [disabled]="!seleccionada" (click)="verAsignatura()">
-          <i class="bi bi-eye me-1"></i> Ver
-        </button>
-        <button class="btn btn-outline-dark" [disabled]="!seleccionada" (click)="abrirEvaluaciones()">
-          <i class="bi bi-ui-checks-grid me-1"></i> Evaluaciones
-        </button>
-      </div>
+    <h3 class="fw-bold mb-4" style="color: #002F5D;">
+      <i class="bi bi-book me-2"></i>Mis Asignaturas
+    </h3>
 
-      <h3 class="fw-bold" style="color: #002F5D;">
-        <i class="bi bi-book me-2"></i>Mis Asignaturas
-      </h3>
-    </div>
-
-    <!-- Tabla de asignaturas -->
-    <div class="card shadow-sm border-0">
-      <div class="card-body p-0">
-        <table class="table table-hover mb-0">
-          <thead class="table-light">
-            <tr>
-              <th>ID</th>
-              <th>Nombre</th>
-              <th>Semestre</th>
-              <th>Plan Académico</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              *ngFor="let a of asignaturas"
-              (click)="seleccionar(a)"
-              [class.table-active]="seleccionada?.ID_Asignatura === a.ID_Asignatura"
-              style="cursor: pointer;"
-            >
-              <td>{{ a.ID_Asignatura }}</td>
-              <td>{{ a.Nombre }}</td>
-              <td>{{ a.Semestre }}</td>
-              <td>{{ a.Plan_Academico }}</td>
-            </tr>
-          </tbody>
-        </table>
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+      <div class="col" *ngFor="let a of asignaturas">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title text-primary">{{ a.Nombre }}</h5>
+            <p class="card-text mb-2">
+              <strong>ID:</strong> {{ a.ID_Asignatura }}<br>
+              <strong>Semestre:</strong> {{ a.Semestre }}<br>
+              <strong>Plan:</strong> {{ a.Plan_Academico }}
+            </p>
+            <div class="mt-auto d-flex gap-2">
+              <button class="btn btn-outline-info btn-sm" (click)="verAsignatura(a)">
+                <i class="bi bi-eye"></i> Ver
+              </button>
+              <button class="btn btn-outline-dark btn-sm" (click)="abrirEvaluaciones(a)">
+                <i class="bi bi-ui-checks-grid"></i> Evaluaciones
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.ts
+++ b/src/app/modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component.ts
@@ -16,7 +16,6 @@ import { DialogEvaluacionesComponent } from '../../profesor/evaluaciones/dialog-
 export class MainAsignaturasProfesorComponent implements OnInit {
   rolUsuario = '';
   asignaturas: any[] = [];
-  seleccionada: any = null;
 
   constructor(
     private modalService: NgbModal,
@@ -35,29 +34,33 @@ export class MainAsignaturasProfesorComponent implements OnInit {
       return;
     }
 
-    this.asignaturaService.obtenerPorProfesor(rut).subscribe(data => {
-      this.asignaturas = data;
-    }, error => {
-      console.error('❌ Error al cargar asignaturas del profesor:', error);
+    this.asignaturaService.obtenerPorProfesor(rut).subscribe(
+      (data) => {
+        this.asignaturas = data;
+      },
+      (error) => {
+        console.error('❌ Error al cargar asignaturas del profesor:', error);
+      }
+    );
+  }
+
+  verAsignatura(asignatura: any) {
+    alert(`Ver asignatura: ${asignatura.Nombre}`);
+  }
+
+  abrirEvaluaciones(asignatura: any) {
+    const modalRef = this.modalService.open(DialogEvaluacionesComponent, {
+      centered: true,
+      size: 'xl',
+      backdrop: 'static',
+      keyboard: false
     });
-  }
+    modalRef.componentInstance.asignatura = asignatura;
 
-  seleccionar(asignatura: any) {
-    this.seleccionada = asignatura;
-  }
-
-  verAsignatura() {
-    if (!this.seleccionada) return;
-    alert(`Ver asignatura: ${this.seleccionada.Nombre}`);
-  }
-
-  abrirEvaluaciones() {
-    if (!this.seleccionada) return;
-    const modalRef = this.modalService.open(DialogEvaluacionesComponent, { centered: true, size: 'xl' });
-    modalRef.componentInstance.asignatura = this.seleccionada;
-
-    modalRef.result.then(res => {
-      if (res === 'actualizado') this.cargarAsignaturas();
-    }).catch(() => {});
+    modalRef.result
+      .then((res) => {
+        if (res === 'actualizado') this.cargarAsignaturas();
+      })
+      .catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- display jefe and professor subject lists as cards with in-row actions
- show cards in jefe/profesor views using bootstrap buttons
- allow selecting same content in multiple evaluations

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842705eb0c4832b8878b831707aa15e