### PR TITLE
Fix typings for Angular components

### DIFF
--- a/src/app/models/criterio.model.ts
+++ b/src/app/models/criterio.model.ts
@@ -3,5 +3,5 @@ export interface Criterio {
   Nombre: string;
   R_Min: number;
   R_Max: number;
-  indicador_ID_Indicador: number;
+  indicador_ID_Indicador?: number;
 }

--- a/src/app/models/indicador.model.ts
+++ b/src/app/models/indicador.model.ts
@@ -1,9 +1,11 @@
 
+import { Criterio } from './criterio.model';
+
 export interface Indicador {
   ID_Indicador?: number;
   Descripcion: string;
   Puntaje_Max: number;
   contenido_ID_Contenido: number;
   ra_ID_RA: number;
-
+  Criterios?: Criterio[];
 }

--- a/src/app/models/resultado-aprendizaje.model.ts
+++ b/src/app/models/resultado-aprendizaje.model.ts
@@ -3,5 +3,5 @@ export interface ResultadoAprendizaje {
   Nombre: string;
   Descripcion: string;
   asignatura_ID_Asignatura: string;
-  competencias?: string; // IDs concatenated
+  competencias?: string | string[]; // IDs concatenated or array of IDs
 }

--- a/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
+++ b/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
@@ -127,7 +127,7 @@ export class DialogRaComponent implements OnInit {
     this.mensajeExito = 'Resultado actualizado correctamente';
 
     const payload = { ...this.ra, competencias: this.competenciasSeleccionadas };
-    this.raService.actualizar(this.ra.ID_RA, payload).subscribe(() => {
+    this.raService.actualizar(this.ra.ID_RA!, payload).subscribe(() => {
       setTimeout(() => this.cerrarConExito(), 1500);
     });
   }
@@ -140,7 +140,7 @@ export class DialogRaComponent implements OnInit {
 
     this.bloqueado = true;
     this.mensajeExito = 'Resultado eliminado';
-    this.raService.eliminar(this.ra.ID_RA).subscribe(() => {
+    this.raService.eliminar(this.ra.ID_RA!).subscribe(() => {
       setTimeout(() => this.cerrarConExito(), 1500);
     });
   }


### PR DESCRIPTION
## Summary
- fix optional field types on Criterio
- extend Indicador model with Criterios
- allow ResultadoAprendizaje to store array of competencias
- assert ID_RA when updating or deleting RAs

## Testing
- `npx tsc -p tsconfig.app.json --noEmit --skipLibCheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6842993cec28832bbebbbe37968edac0