### PR TITLE
Move inscripcion action into each subject

### DIFF
--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -12,9 +12,6 @@
         <button class="btn btn-outline-primary" (click)="abrirDialogEstudiantes()">
           <i class="bi bi-people-fill me-1"></i> Estudiantes
         </button>
-        <button class="btn btn-outline-success" [disabled]="!seleccionada" (click)="abrirDialogInscripcion()">
-          <i class="bi bi-person-check-fill me-1"></i> Inscribir
-        </button>
       </div>
       <h3 class="fw-bold text-nowrap" style="color: #002F5D;">
         <i class="bi bi-journal-text me-2"></i>Gestión de Asignaturas
@@ -37,12 +34,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr
-                *ngFor="let asignatura of grupo.asignaturas"
-                (click)="seleccionar(asignatura)"
-                [class.table-active]="seleccionada?.ID_Asignatura === asignatura.ID_Asignatura"
-                style="cursor: pointer;"
-              >
+              <tr *ngFor="let asignatura of grupo.asignaturas" style="cursor: pointer;">
                 <td>{{ asignatura.ID_Asignatura }}</td>
                 <td>{{ asignatura.Nombre }}</td>
                 <td>{{ asignatura.Profesor }}</td>
@@ -60,6 +52,11 @@
                       <li>
                         <a class="dropdown-item" (click)="abrirDialog('editar', asignatura)">
                           <i class="bi bi-pencil-square me-1"></i> Editar
+                        </a>
+                      </li>
+                      <li>
+                        <a class="dropdown-item" (click)="abrirDialogInscripcion(asignatura)">
+                          <i class="bi bi-person-check-fill me-1"></i> Inscribir
                         </a>
                       </li>
                     </ul>

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -19,7 +19,6 @@ import { SidebarComponent } from '../../../../shared/components/sidebar/sidebar.
 export class MainAsignaturasComponent implements OnInit {
   rolUsuario: string = '';
   asignaturasPorCarrera: { carrera: string; asignaturas: Asignatura[] }[] = [];
-  seleccionada: Asignatura | null = null;
 
   constructor(
     private modalService: NgbModal,
@@ -46,11 +45,7 @@ export class MainAsignaturasComponent implements OnInit {
     });
   }
 
-  seleccionar(asignatura: Asignatura) {
-    this.seleccionada = asignatura;
-  }
-
-  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: Asignatura | null) {
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: Asignatura) {
 
     const modalRef = this.modalService.open(DialogAsignaturaComponent, {
       centered: true,
@@ -58,7 +53,7 @@ export class MainAsignaturasComponent implements OnInit {
       keyboard: false
     });
     modalRef.componentInstance.modo = modo;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura ?? this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -78,15 +73,14 @@ export class MainAsignaturasComponent implements OnInit {
     }).catch(() => {});
   }
 
-  abrirDialogInscripcion() {
-    if (!this.seleccionada) return;
+  abrirDialogInscripcion(asignatura: Asignatura) {
     const modalRef = this.modalService.open(DialogInscripcionComponent, {
       centered: true,
       size: 'lg',
       backdrop: 'static',
       keyboard: false
     });
-    modalRef.componentInstance.asignatura = this.seleccionada;
+    modalRef.componentInstance.asignatura = asignatura;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();


### PR DESCRIPTION
## Summary
- simplify admin subjects component logic
- move `Inscribir` action inside the per-row dropdown

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a8130a68832bbdc257ee9a988632