### PR TITLE
Move estudiante actions to dropdown

### DIFF
--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
@@ -13,12 +13,6 @@
       <button class="btn btn-success me-2" (click)="nuevoEstudiante()">
         <i class="bi bi-plus-circle me-1"></i> Nuevo Estudiante
       </button>
-      <button class="btn btn-info me-2 text-white" [disabled]="!seleccionado" (click)="verEstudiante()">
-        <i class="bi bi-eye me-1"></i> Ver
-      </button>
-      <button class="btn btn-warning text-white" [disabled]="!seleccionado" (click)="editarEstudiante()">
-        <i class="bi bi-pencil-square me-1"></i> Editar
-      </button>
     </div>
 
     <div>
@@ -43,24 +37,28 @@
           </tr>
         </thead>
         <tbody>
-          <tr
-            *ngFor="let est of estudiantes"
-            (click)="seleccionar(est)"
-            [class.table-active]="seleccionado?.ID_Estudiante === est.ID_Estudiante"
-            style="cursor: pointer;"
-          >
+          <tr *ngFor="let est of estudiantes" style="cursor: pointer;">
             <td>{{ est.ID_Estudiante }}</td>
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
             <td>{{ est.Anio_Ingreso }}</td>
             <td class="text-end">
-              <div class="btn-group btn-group-sm">
-                <button class="btn btn-outline-info" (click)="abrirFormulario('ver')">
-                  <i class="bi bi-eye"></i>
+              <div class="dropdown">
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
+                  <i class="bi bi-three-dots-vertical"></i>
                 </button>
-                <button class="btn btn-outline-warning text-dark" (click)="abrirFormulario('editar')">
-                  <i class="bi bi-pencil-square"></i>
-                </button>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <li>
+                    <a class="dropdown-item" (click)="abrirFormulario('ver', est)">
+                      <i class="bi bi-eye me-1"></i> Ver
+                    </a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" (click)="abrirFormulario('editar', est)">
+                      <i class="bi bi-pencil-square me-1"></i> Editar
+                    </a>
+                  </li>
+                </ul>
               </div>
             </td>
           </tr>

--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
@@ -15,7 +15,6 @@ import { Estudiante } from '../../../../models';
 })
 export class DialogEstudiantesComponent implements OnInit {
   estudiantes: Estudiante[] = [];
-  seleccionado: Estudiante | null = null;
   bloqueado = false;
   mensajeCSV = '';
   mostrarToastCSV = false;
@@ -36,30 +35,18 @@ export class DialogEstudiantesComponent implements OnInit {
     });
   }
 
-  seleccionar(est: Estudiante) {
-    this.seleccionado = est;
-  }
-
   nuevoEstudiante() {
     this.abrirFormulario('crear');
   }
 
-  verEstudiante() {
-    if (this.seleccionado) this.abrirFormulario('ver');
-  }
-
-  editarEstudiante() {
-    if (this.seleccionado) this.abrirFormulario('editar');
-  }
-
-  abrirFormulario(modo: 'crear' | 'ver' | 'editar') {
+  abrirFormulario(modo: 'crear' | 'ver' | 'editar', est?: Estudiante) {
     const modalRef = this.modalService.open(DialogFormEstudianteComponent, {
       centered: true,
       backdrop: 'static',
       keyboard: false
     });
     modalRef.componentInstance.modo = modo;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : this.seleccionado;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : est;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarEstudiantesNoInscritos();

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -12,9 +12,6 @@
         <button class="btn btn-outline-primary" (click)="abrirDialogEstudiantes()">
           <i class="bi bi-people-fill me-1"></i> Estudiantes
         </button>
-        <button class="btn btn-outline-success" [disabled]="!seleccionada" (click)="abrirDialogInscripcion()">
-          <i class="bi bi-person-check-fill me-1"></i> Inscribir
-        </button>
       </div>
       <h3 class="fw-bold text-nowrap" style="color: #002F5D;">
         <i class="bi bi-journal-text me-2"></i>Gestión de Asignaturas
@@ -37,12 +34,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr
-                *ngFor="let asignatura of grupo.asignaturas"
-                (click)="seleccionar(asignatura)"
-                [class.table-active]="seleccionada?.ID_Asignatura === asignatura.ID_Asignatura"
-                style="cursor: pointer;"
-              >
+              <tr *ngFor="let asignatura of grupo.asignaturas" style="cursor: pointer;">
                 <td>{{ asignatura.ID_Asignatura }}</td>
                 <td>{{ asignatura.Nombre }}</td>
                 <td>{{ asignatura.Profesor }}</td>
@@ -60,6 +52,11 @@
                       <li>
                         <a class="dropdown-item" (click)="abrirDialog('editar', asignatura)">
                           <i class="bi bi-pencil-square me-1"></i> Editar
+                        </a>
+                      </li>
+                      <li>
+                        <a class="dropdown-item" (click)="abrirDialogInscripcion(asignatura)">
+                          <i class="bi bi-person-check-fill me-1"></i> Inscribir
                         </a>
                       </li>
                     </ul>

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -19,7 +19,6 @@ import { SidebarComponent } from '../../../../shared/components/sidebar/sidebar.
 export class MainAsignaturasComponent implements OnInit {
   rolUsuario: string = '';
   asignaturasPorCarrera: { carrera: string; asignaturas: Asignatura[] }[] = [];
-  seleccionada: Asignatura | null = null;
 
   constructor(
     private modalService: NgbModal,
@@ -46,11 +45,7 @@ export class MainAsignaturasComponent implements OnInit {
     });
   }
 
-  seleccionar(asignatura: Asignatura) {
-    this.seleccionada = asignatura;
-  }
-
-  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: Asignatura | null) {
+  abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: Asignatura) {
 
     const modalRef = this.modalService.open(DialogAsignaturaComponent, {
       centered: true,
@@ -58,7 +53,7 @@ export class MainAsignaturasComponent implements OnInit {
       keyboard: false
     });
     modalRef.componentInstance.modo = modo;
-    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura ?? this.seleccionada;
+    modalRef.componentInstance.datos = modo === 'crear' ? null : asignatura;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
@@ -78,15 +73,14 @@ export class MainAsignaturasComponent implements OnInit {
     }).catch(() => {});
   }
 
-  abrirDialogInscripcion() {
-    if (!this.seleccionada) return;
+  abrirDialogInscripcion(asignatura: Asignatura) {
     const modalRef = this.modalService.open(DialogInscripcionComponent, {
       centered: true,
       size: 'lg',
       backdrop: 'static',
       keyboard: false
     });
-    modalRef.componentInstance.asignatura = this.seleccionada;
+    modalRef.componentInstance.asignatura = asignatura;
 
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();


### PR DESCRIPTION
## Summary
- replace per-row student buttons with 3-dot dropdown menu

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a8130a68832bbdc257ee9a988632