### PR TITLE
Update user dialog design

### DIFF
--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
@@ -1,10 +1,18 @@
-<div class="modal-header" style="background-color: #002f5d">
-  <h5 class="modal-title text-white">
-    {{ modo === 'crear' ? 'Registrar Usuario' : 'Detalles de Usuario' }}
+<div class="modal-header">
+  <h5 class="modal-title d-flex align-items-center gap-2" style="color: #002F5D">
+    <i class="bi bi-person-fill"></i>
+    {{
+      modo === 'crear'
+        ? 'Crear Usuario'
+        : modo === 'editar'
+        ? 'Editar Usuario'
+        : 'Ver Usuario'
+    }}
   </h5>
-  <button type="button" class="btn-close btn-close-white" aria-label="Cerrar" (click)="cancelar()"></button>
+  <button type="button" class="btn-close" (click)="cancelar()" [disabled]="bloqueado"></button>
 </div>
-<div class="modal-body">
+
+<div class="modal-body position-relative">
   <form *ngIf="modo === 'crear'">
     <div class="mb-3">
       <label class="form-label">RUT</label>
@@ -53,19 +61,61 @@
     </div>
   </div>
 
-  <div *ngIf="mensajeError" class="alert alert-danger" role="alert">
-    {{ mensajeError }}
+  <!-- Confirmación -->
+  <div *ngIf="accionConfirmada && !bloqueado" class="confirm-overlay shadow p-4 rounded border mt-3" style="background-color: #f9f9f9;">
+    <h5 class="mb-3">
+      <i
+        class="bi"
+        [ngClass]="{
+          'bi-check-circle-fill': accionConfirmada === 'crear',
+          'bi-pencil-fill': accionConfirmada === 'actualizar'
+        }"
+      ></i>
+      Confirmar {{ accionConfirmada }}
+    </h5>
+
+    <p>¿Estás seguro de que deseas <strong>{{ accionConfirmada }}</strong> este usuario?</p>
+
+    <div class="d-flex justify-content-end gap-2 mt-3">
+      <button class="btn btn-success btn-sm text-white" *ngIf="accionConfirmada === 'crear'" (click)="crear()">Sí, crear</button>
+      <button class="btn btn-primary btn-sm text-white" *ngIf="accionConfirmada === 'actualizar'" (click)="renovarClave()">Sí, actualizar</button>
+      <button class="btn btn-outline-secondary btn-sm" (click)="cancelarConfirmacion()">Cancelar</button>
+    </div>
   </div>
-  <div *ngIf="mensajeExito" class="alert alert-success" role="alert" (click)="cerrarToast()">
-    {{ mensajeExito }}
+
+  <div *ngIf="mensajeError && !bloqueado" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+    <div class="toast show text-bg-danger bg-opacity-75" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          <i class="bi bi-exclamation-octagon-fill me-2"></i>{{ mensajeError }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div *ngIf="mensajeExito && bloqueado" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+    <div class="toast show text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          <i class="bi bi-check-circle-fill me-2"></i>{{ mensajeExito }}
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" (click)="cerrarToast()"></button>
+      </div>
+    </div>
   </div>
 </div>
-<div class="modal-footer">
-  <button type="button" class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cerrar</button>
-  <button *ngIf="modo === 'editar'" type="button" class="btn btn-primary" (click)="renovarClave()" [disabled]="bloqueado">
-    Guardar
+
+<!-- FOOTER -->
+<div class="modal-footer" *ngIf="modo !== 'ver' && !mensajeExito && !accionConfirmada">
+  <button *ngIf="modo === 'crear'" class="btn btn-primary" (click)="crear()" [disabled]="bloqueado">
+    <i class="bi bi-plus-circle me-1"></i> Crear
   </button>
-  <button *ngIf="modo === 'crear'" type="button" class="btn btn-primary" (click)="crear()" [disabled]="bloqueado">
-    Registrar
+  <button *ngIf="modo === 'editar'" class="btn btn-success" (click)="renovarClave()" [disabled]="bloqueado">
+    <i class="bi bi-pencil-square me-1"></i> Guardar
   </button>
+  <button class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cancelar</button>
+</div>
+
+<div class="modal-footer" *ngIf="modo === 'ver' || mensajeExito">
+  <button class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cerrar</button>
 </div>

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
@@ -24,6 +24,7 @@ export class DialogUsuarioComponent {
   mensajeExito = '';
   mensajeError = '';
   bloqueado = false;
+  accionConfirmada: 'crear' | 'actualizar' | null = null;
   private modalCerrado = false;
 
   constructor(
@@ -55,13 +56,19 @@ export class DialogUsuarioComponent {
       setTimeout(() => (this.mensajeError = ''), 3000);
       return;
     }
+    if (!this.accionConfirmada) {
+      this.accionConfirmada = 'actualizar';
+      return;
+    }
 
     if (this.bloqueado) return;
     this.bloqueado = true;
-    this.usuarioService.actualizarClave(this.usuario.ID_Usuario, this.nuevaClave).subscribe(() => {
-      this.mensajeExito = 'Clave actualizada';
-      setTimeout(() => this.cerrarConExito(), 1500);
-    });
+    this.usuarioService
+      .actualizarClave(this.usuario.ID_Usuario, this.nuevaClave)
+      .subscribe(() => {
+        this.mensajeExito = 'Clave actualizada';
+        setTimeout(() => this.cerrarConExito(), 1500);
+      });
   }
 
   crear() {
@@ -76,6 +83,11 @@ export class DialogUsuarioComponent {
       return;
     }
 
+    if (!this.accionConfirmada) {
+      this.accionConfirmada = 'crear';
+      return;
+    }
+
     if (this.bloqueado) return;
     this.bloqueado = true;
     this.usuarioService.crearUsuario(this.usuario).subscribe(() => {
@@ -86,6 +98,10 @@ export class DialogUsuarioComponent {
 
   cancelar() {
     if (!this.bloqueado) this.modal.dismiss();
+  }
+
+  cancelarConfirmacion() {
+    this.accionConfirmada = null;
   }
 
   cerrarToast() {


### PR DESCRIPTION
## Summary
- restyle the admin user dialog to match other modules
- add action confirmation and toasts for create/update

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b0d8c7a4832bab9230d3790c7b53