### PR TITLE
Restore admin student management button

### DIFF
--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -10,6 +10,10 @@
           <i class="bi bi-plus-circle me-1"></i> Nueva Asignatura
         </button>
 
+        <button class="btn btn-primary" (click)="abrirDialogEstudiantes()">
+          <i class="bi bi-people-fill me-1"></i> Estudiantes
+        </button>
+
       </div>
       <h3 class="fw-bold text-nowrap" style="color: #002F5D;">
         <i class="bi bi-journal-text me-2"></i>Gestión de Asignaturas

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -4,6 +4,7 @@ import { NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { DialogAsignaturaComponent } from '../dialog-asignatura/dialog-asignatura.component';
 import { DialogInscripcionComponent } from '../dialog-inscripcion/dialog-inscripcion.component';
+import { DialogEstudiantesComponent } from '../dialog-estudiantes/dialog-estudiantes.component';
 import { AsignaturaService } from '../../../../services/asignatura.service';
 import { Asignatura } from '../../../../models';
 import { SidebarComponent } from '../../../../shared/components/sidebar/sidebar.component';
@@ -72,5 +73,16 @@ export class MainAsignaturasComponent implements OnInit {
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarAsignaturas();
     }).catch(() => {});
+  }
+
+  abrirDialogEstudiantes() {
+    const modalRef = this.modalService.open(DialogEstudiantesComponent, {
+      centered: true,
+      size: 'lg',
+      backdrop: 'static',
+      keyboard: false
+    });
+
+    modalRef.result.catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- allow admin to open dialog of students from subject page
- add new button for managing students

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439756977c832b8534fa0566e45d62