### PR TITLE
Fix RA visibility for committee

### DIFF
--- a/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
+++ b/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
@@ -51,8 +51,13 @@ export class DialogRaComponent implements OnInit {
 
   ngOnInit(): void {
     const rut = localStorage.getItem('rut') || '';
-    if (rut) {
-      this.asignaturaService.obtenerPorCarreraDelJefe(rut).subscribe(data => {
+    const rol = localStorage.getItem('rol') || '';
+    if (rol === 'Comité Curricular') {
+      this.asignaturaService.obtenerTodas().subscribe((data) => {
+        this.asignaturas = data;
+      });
+    } else if (rut) {
+      this.asignaturaService.obtenerPorCarreraDelJefe(rut).subscribe((data) => {
         this.asignaturas = data;
       });
     }

--- a/src/app/modules/competencia-ra/ra-main/ra-main.component.ts
+++ b/src/app/modules/competencia-ra/ra-main/ra-main.component.ts
@@ -35,22 +35,27 @@ export class MainRaComponent implements OnInit {
 
   cargarRA() {
     const rut = localStorage.getItem('rut') || '';
-    if (!rut) return;
+    if (!rut && this.rolUsuario !== 'Comité Curricular') return;
 
     this.raService.obtenerTodos().subscribe((data) => {
-      this.asignaturaService.obtenerPorCarreraDelJefe(rut).subscribe((asignaturas) => {
+      const obtenerAsignaturas =
+        this.rolUsuario === 'Comité Curricular'
+          ? this.asignaturaService.obtenerTodas()
+          : this.asignaturaService.obtenerPorCarreraDelJefe(rut);
+
+      obtenerAsignaturas.subscribe((listaAsignaturas) => {
         const mapa = new Map<string, any>();
 
         for (let ra of data) {
           const idAsig = ra.asignatura_ID_Asignatura;
-          const asignatura = asignaturas.find((a) => a.ID_Asignatura === idAsig);
+          const asig = listaAsignaturas.find((a) => a.ID_Asignatura === idAsig);
 
-          if (!asignatura) continue;
+          if (!asig) continue;
 
           if (!mapa.has(idAsig)) {
             mapa.set(idAsig, {
               asignatura: idAsig,
-              nombreAsignatura: asignatura.Nombre,
+              nombreAsignatura: asig.Nombre,
               ras: [],
             });
           }


### PR DESCRIPTION
## Summary
- allow Comité Curricular users to load all subjects when working with RAs
- list all RAs grouped by subject for Comité Curricular

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843999b3d84832bbb57c949f8c56a04