### PR TITLE
Allow editing criteria inline

### DIFF
--- a/src/app/modules/rubricas/dialog-form-indicador/dialog-form-indicador.component.html
+++ b/src/app/modules/rubricas/dialog-form-indicador/dialog-form-indicador.component.html
@@ -45,20 +45,46 @@
         </thead>
         <tbody>
           <tr *ngFor="let c of indicador.Criterios; let i = index">
-            <td>{{ c.Nombre }}</td>
-            <td>{{ c.R_Min }}</td>
-            <td>{{ c.R_Max }}</td>
+            <td>
+              <input
+                type="text"
+                class="form-control form-control-sm"
+                [(ngModel)]="c.Nombre"
+                name="nombre{{ i }}"
+                [ngModelOptions]="{ standalone: true }"
+                [disabled]="bloqueado"
+              />
+            </td>
+            <td>
+              <input
+                type="number"
+                class="form-control form-control-sm"
+                [(ngModel)]="c.R_Min"
+                name="rmin{{ i }}"
+                [ngModelOptions]="{ standalone: true }"
+                min="1"
+                [disabled]="bloqueado"
+              />
+            </td>
+            <td>
+              <input
+                type="number"
+                class="form-control form-control-sm"
+                [(ngModel)]="c.R_Max"
+                name="rmax{{ i }}"
+                [ngModelOptions]="{ standalone: true }"
+                min="1"
+                [disabled]="bloqueado"
+              />
+            </td>
             <td>
               <button class="btn btn-sm btn-outline-danger" (click)="eliminarCriterio(i)" [disabled]="bloqueado">
-                <i class="bi bi-trash"></i>
+                <i class="bi bi-dash-circle"></i>
               </button>
             </td>
           </tr>
           <tr>
-            <td><input type="text" class="form-control form-control-sm" [(ngModel)]="criterioTemp.Nombre" name="nombreTemp" /></td>
-            <td><input type="number" class="form-control form-control-sm" [(ngModel)]="criterioTemp.R_Min" name="rmin" min="1" /></td>
-            <td><input type="number" class="form-control form-control-sm" [(ngModel)]="criterioTemp.R_Max" name="rmax" min="1" /></td>
-            <td>
+            <td colspan="4" class="text-end">
               <button class="btn btn-sm btn-outline-success" (click)="agregarCriterio()" [disabled]="bloqueado">
                 <i class="bi bi-plus-circle"></i>
               </button>

--- a/src/app/modules/rubricas/dialog-form-indicador/dialog-form-indicador.component.ts
+++ b/src/app/modules/rubricas/dialog-form-indicador/dialog-form-indicador.component.ts
@@ -28,7 +28,6 @@ export class DialogFormIndicadorComponent implements OnInit {
     Criterios: [] as { Nombre: string; R_Min: number; R_Max: number }[]
   };
 
-  criterioTemp = { Nombre: '', R_Min: 1, R_Max: 1 };
   ras: ResultadoAprendizaje[] = [];
 
   mensajeExito = '';
@@ -43,7 +42,9 @@ export class DialogFormIndicadorComponent implements OnInit {
     private raService: RaService
   ) {}
 ngOnInit(): void {
-  console.log('🧪 contenidoID recibido:', this.contenidoID); // <-- esto
+  if (!this.contenidoID && this.datos?.contenido_ID_Contenido) {
+    this.contenidoID = this.datos.contenido_ID_Contenido;
+  }
 
   this.cargarRAs();
 
@@ -59,6 +60,11 @@ ngOnInit(): void {
       try {
         this.indicador.Criterios = JSON.parse(copia);
       } catch (e) {}
+    }
+    if (this.indicador.Criterios.length < 4) {
+      for (let i = this.indicador.Criterios.length; i < 4; i++) {
+        this.indicador.Criterios.push({ Nombre: '', R_Min: 1, R_Max: 1 });
+      }
     }
   }
 }
@@ -91,46 +97,7 @@ ngOnInit(): void {
   }
 
   agregarCriterio() {
-    const { Nombre, R_Min, R_Max } = this.criterioTemp;
-
-    if (!Nombre || R_Min == null || R_Max == null) {
-      this.mensajeError = 'Complete los campos del criterio.';
-      setTimeout(() => (this.mensajeError = ''), 3000);
-      return;
-    }
-
-    if (R_Min > R_Max) {
-      this.mensajeError = 'El rango mínimo no puede ser mayor al máximo.';
-      setTimeout(() => (this.mensajeError = ''), 3000);
-      return;
-    }
-
-    const totalAsignado = this.indicador.Criterios.reduce(
-      (sum, c) => sum + (c.R_Max - c.R_Min + 1),
-      0
-    );
-    const nuevoRango = R_Max - R_Min + 1;
-
-    if ((totalAsignado + nuevoRango) > this.indicador.Puntaje_Max) {
-      this.mensajeError = 'La suma de los rangos supera el puntaje máximo.';
-      setTimeout(() => (this.mensajeError = ''), 3000);
-      return;
-    }
-
-    const existeSolapamiento = this.indicador.Criterios.some(
-      c =>
-        (R_Min >= c.R_Min && R_Min <= c.R_Max) ||
-        (R_Max >= c.R_Min && R_Max <= c.R_Max)
-    );
-
-    if (existeSolapamiento) {
-      this.mensajeError = 'Este rango se solapa con otro criterio.';
-      setTimeout(() => (this.mensajeError = ''), 3000);
-      return;
-    }
-
-    this.indicador.Criterios.push({ ...this.criterioTemp });
-    this.criterioTemp = { Nombre: '', R_Min: 1, R_Max: 1 };
+    this.indicador.Criterios.push({ Nombre: '', R_Min: 1, R_Max: 1 });
   }
 
   eliminarCriterio(index: number) {
@@ -140,6 +107,12 @@ ngOnInit(): void {
   validarRangosCompletos(): boolean {
     const totalEsperado = this.indicador.Puntaje_Max;
     const rangos = this.indicador.Criterios.map(c => ({ ...c })).sort((a, b) => a.R_Min - b.R_Min);
+
+    for (const r of rangos) {
+      if (!r.Nombre || r.R_Min == null || r.R_Max == null || r.R_Min > r.R_Max) {
+        return false;
+      }
+    }
 
     let actual = 1;
     for (const r of rangos) {
@@ -158,7 +131,7 @@ ngOnInit(): void {
     }
 
     if (!this.validarRangosCompletos()) {
-      this.mensajeError = 'Los criterios no cubren el rango completo del puntaje o tienen huecos.';
+      this.mensajeError = 'Verifique que todos los criterios sean válidos y cubran el puntaje máximo sin huecos.';
       setTimeout(() => (this.mensajeError = ''), 3000);
       return;
     }
@@ -185,7 +158,7 @@ ngOnInit(): void {
     }
 
     if (!this.validarRangosCompletos()) {
-      this.mensajeError = 'Los criterios no cubren el rango completo del puntaje.';
+      this.mensajeError = 'Verifique que todos los criterios sean válidos y cubran el puntaje máximo sin huecos.';
       setTimeout(() => (this.mensajeError = ''), 3000);
       return;
     }

--- a/src/app/modules/rubricas/dialog-rubrica/dialog-rubrica.component.ts
+++ b/src/app/modules/rubricas/dialog-rubrica/dialog-rubrica.component.ts
@@ -64,6 +64,7 @@ export class DialogRubricaComponent implements OnInit {
     });
     modalRef.componentInstance.modo = 'editar';
     modalRef.componentInstance.datos = indicador;
+    modalRef.componentInstance.contenidoID = indicador.contenido_ID_Contenido;
 
     modalRef.result
       .then((res) => {
@@ -81,6 +82,7 @@ export class DialogRubricaComponent implements OnInit {
     });
     modalRef.componentInstance.modo = 'ver';
     modalRef.componentInstance.datos = indicador;
+    modalRef.componentInstance.contenidoID = indicador.contenido_ID_Contenido;
   }
 
   get columnasMaximas(): number[] {


### PR DESCRIPTION
## Summary
- show editable inputs for each criterio
- ensure at least four criterios when creating a new indicador
- replace trash icons with minus icons
- update validation and add button row
- fix NG01352 error by setting criterion inputs as standalone
- give each criterio input a unique name
- load RA list correctly when editing or viewing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439c7708f4832bb9b24045ba0aa018