### PR TITLE
Fix RA selection in rubric dialog

### DIFF
--- a/src/app/modules/rubricas/dialog-rubrica/dialog-rubrica.component.ts
+++ b/src/app/modules/rubricas/dialog-rubrica/dialog-rubrica.component.ts
@@ -63,6 +63,7 @@ export class DialogRubricaComponent implements OnInit {
       keyboard: false,
     });
     modalRef.componentInstance.modo = 'editar';
+    modalRef.componentInstance.contenidoID = this.contenidoID;
     modalRef.componentInstance.datos = indicador;
 
     modalRef.result
@@ -80,6 +81,7 @@ export class DialogRubricaComponent implements OnInit {
       keyboard: false,
     });
     modalRef.componentInstance.modo = 'ver';
+    modalRef.componentInstance.contenidoID = this.contenidoID;
     modalRef.componentInstance.datos = indicador;
   }
 


### PR DESCRIPTION
## Summary
- ensure the indicator dialog always receives `contenidoID` when viewing or editing

## Testing
- `npx ng test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843a3858da4832bbf11de33bf3efd46