### PR TITLE
Improve evaluation card style

### DIFF
--- a/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.html
@@ -16,18 +16,24 @@
     No hay evaluaciones registradas para esta asignatura.
   </div>
 
-  <div *ngFor="let eva of evaluaciones" class="card border-primary mb-3">
-    <div class="card-body">
-      <h5 class="card-title text-primary">{{ eva.Nombre }}</h5>
-      <p class="card-text text-muted">
-        Tipo: {{ eva.Tipo }} |
-        Instancia: {{ eva.N_Instancia }} |
-        Fecha: {{ eva.Fecha | date:'longDate' }}
-      </p>
-      <div class="text-end">
-        <button class="btn btn-outline-primary btn-sm" (click)="abrirDetalleEvaluacion(eva.ID_Evaluacion)">
-          <i class="bi bi-eye me-1"></i> Ver Detalle
-        </button>
+  <div class="row row-cols-1 row-cols-md-2 g-4" *ngIf="evaluaciones.length > 0">
+    <div class="col" *ngFor="let eva of evaluaciones">
+      <div class="card h-100 shadow-sm border-start border-4 border-primary">
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title text-primary d-flex align-items-center">
+            <i class="bi bi-journal-text me-2"></i>{{ eva.Nombre }}
+          </h5>
+          <p class="card-text mb-2">
+            <strong>Tipo:</strong> {{ eva.Tipo }}<br>
+            <strong>Instancia:</strong> {{ eva.N_Instancia }}<br>
+            <strong>Fecha:</strong> {{ eva.Fecha | date:'longDate' }}
+          </p>
+          <div class="mt-auto text-end">
+            <button class="btn btn-outline-primary btn-sm" (click)="abrirDetalleEvaluacion(eva.ID_Evaluacion)">
+              <i class="bi bi-eye me-1"></i> Ver Detalle
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- redesign evaluation listing with a grid of cards so data is displayed nicely

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843a82e312c832b9bafc056ea0ba552