### PR TITLE
Improve evaluation deletion

### DIFF
--- a/backend/controllers/evaluacion.controller.js
+++ b/backend/controllers/evaluacion.controller.js
@@ -41,3 +41,13 @@ exports.obtenerContenidosUsados = async (req, res) => {
     res.status(500).json({ message: 'Error interno del servidor' });
   }
 };
+
+exports.eliminar = async (req, res) => {
+  try {
+    await EvaluacionService.eliminar(req.params.id);
+    res.json({ message: 'Evaluación eliminada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error al eliminar evaluación' });
+  }
+};

--- a/backend/routes/evaluacion.routes.js
+++ b/backend/routes/evaluacion.routes.js
@@ -6,5 +6,6 @@ router.get('/contar/:idAsignatura', controller.contarPorAsignatura);
 router.post('/crear-con-aplicaciones', controller.crearConAplicaciones);
 router.get('/por-asignatura/:id', controller.obtenerPorAsignatura);
 router.get('/contenidos-usados/:asignaturaID', controller.obtenerContenidosUsados);
+router.delete('/eliminar/:id', controller.eliminar);
 
 module.exports = router;

--- a/backend/services/evaluacion.service.js
+++ b/backend/services/evaluacion.service.js
@@ -125,3 +125,33 @@ exports.obtenerContenidosUsados = (asignaturaID) => {
     });
   });
 };
+
+exports.eliminar = (id) => {
+  const borrarAplicaciones = 'DELETE FROM aplicacion WHERE evaluacion_ID_Evaluacion = ?';
+  const borrarEvaluacion = 'DELETE FROM evaluacion WHERE ID_Evaluacion = ?';
+
+  return new Promise((resolve, reject) => {
+    connection.beginTransaction((err) => {
+      if (err) return reject(err);
+
+      connection.query(borrarAplicaciones, [id], (err1) => {
+        if (err1) {
+          return connection.rollback(() => reject(err1));
+        }
+
+        connection.query(borrarEvaluacion, [id], (err2) => {
+          if (err2) {
+            return connection.rollback(() => reject(err2));
+          }
+
+          connection.commit((err3) => {
+            if (err3) {
+              return connection.rollback(() => reject(err3));
+            }
+            resolve();
+          });
+        });
+      });
+    });
+  });
+};

--- a/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.html
@@ -16,18 +16,57 @@
     No hay evaluaciones registradas para esta asignatura.
   </div>
 
-  <div *ngFor="let eva of evaluaciones" class="card border-primary mb-3">
-    <div class="card-body">
-      <h5 class="card-title text-primary">{{ eva.Nombre }}</h5>
-      <p class="card-text text-muted">
-        Tipo: {{ eva.Tipo }} |
-        Instancia: {{ eva.N_Instancia }} |
-        Fecha: {{ eva.Fecha | date:'longDate' }}
-      </p>
-      <div class="text-end">
-        <button class="btn btn-outline-primary btn-sm" (click)="abrirDetalleEvaluacion(eva.ID_Evaluacion)">
-          <i class="bi bi-eye me-1"></i> Ver Detalle
-        </button>
+  <div class="row row-cols-1 row-cols-md-2 g-4" *ngIf="evaluaciones.length > 0">
+    <div class="col" *ngFor="let eva of evaluaciones">
+      <div class="card h-100 shadow-sm border-start border-4 border-primary">
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title text-primary d-flex align-items-center">
+            <i class="bi bi-journal-text me-2"></i>{{ eva.Nombre }}
+          </h5>
+          <p class="card-text mb-2">
+            <strong>Tipo:</strong> {{ eva.Tipo }}<br>
+            <strong>Instancia:</strong> {{ eva.N_Instancia }}<br>
+            <strong>Fecha:</strong> {{ eva.Fecha | date:'longDate' }}
+          </p>
+          <div class="mt-auto text-end" *ngIf="accionConfirmada !== eva.ID_Evaluacion">
+            <button class="btn btn-outline-primary btn-sm me-2" (click)="abrirDetalleEvaluacion(eva.ID_Evaluacion)">
+              <i class="bi bi-eye me-1"></i> Ver Detalle
+            </button>
+            <button class="btn btn-outline-danger btn-sm" (click)="confirmarEliminar(eva.ID_Evaluacion)">
+              <i class="bi bi-trash"></i>
+            </button>
+          </div>
+
+          <div *ngIf="accionConfirmada === eva.ID_Evaluacion" class="confirm-overlay shadow p-3 rounded mt-2">
+            <p class="mb-2">¿Eliminar esta evaluación?</p>
+            <div class="d-flex justify-content-end gap-2">
+              <button class="btn btn-danger btn-sm text-white" (click)="eliminarConfirmado(eva.ID_Evaluacion)">Sí</button>
+              <button class="btn btn-outline-secondary btn-sm" (click)="cancelarConfirmacion()">No</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Toast Éxito -->
+<div *ngIf="mensajeExito" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+  <div class="toast show text-bg-success" role="alert">
+    <div class="d-flex">
+      <div class="toast-body">
+        <i class="bi bi-check-circle-fill me-2"></i>{{ mensajeExito }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Toast Error -->
+<div *ngIf="mensajeError" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+  <div class="toast show text-bg-danger bg-opacity-75" role="alert">
+    <div class="d-flex">
+      <div class="toast-body">
+        <i class="bi bi-exclamation-octagon-fill me-2"></i>{{ mensajeError }}
       </div>
     </div>
   </div>

--- a/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-evaluaciones/dialog-evaluaciones/dialog-evaluaciones.component.ts
@@ -17,6 +17,10 @@ export class DialogEvaluacionesComponent implements OnInit {
   @Input() asignatura: any;
 
   evaluaciones: any[] = [];
+  accionConfirmada: number | null = null;
+  mensajeExito = '';
+  mensajeError = '';
+  bloqueado = false;
 
   constructor(
     public modal: NgbActiveModal,
@@ -64,6 +68,34 @@ export class DialogEvaluacionesComponent implements OnInit {
     modalRef.result.then(res => {
       if (res === 'actualizado') this.cargarEvaluaciones();
     }).catch(() => {});
+  }
+
+  confirmarEliminar(id: number) {
+    this.accionConfirmada = id;
+  }
+
+  cancelarConfirmacion() {
+    this.accionConfirmada = null;
+  }
+
+  eliminarConfirmado(id: number) {
+    this.bloqueado = true;
+    this.evaluacionService.eliminar(id).subscribe({
+      next: () => {
+        this.mensajeExito = 'Evaluación eliminada';
+        this.accionConfirmada = null;
+        setTimeout(() => {
+          this.mensajeExito = '';
+          this.bloqueado = false;
+          this.cargarEvaluaciones();
+        }, 1500);
+      },
+      error: () => {
+        this.bloqueado = false;
+        this.mensajeError = 'No se pudo eliminar la evaluación';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
+    });
   }
 
   cerrar() {

--- a/src/app/services/evaluacion.service.ts
+++ b/src/app/services/evaluacion.service.ts
@@ -25,7 +25,11 @@ export class EvaluacionService {
     return this.http.get<Evaluacion[]>(`${this.apiUrl}/por-asignatura/${asignaturaID}`);
   }
   obtenerContenidosUsados(asignaturaID: string): Observable<number[]> {
-  return this.http.get<number[]>(`${this.apiUrl}/contenidos-usados/${asignaturaID}`);
-}
+    return this.http.get<number[]>(`${this.apiUrl}/contenidos-usados/${asignaturaID}`);
+  }
+
+  eliminar(id: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/eliminar/${id}`);
+  }
 
 }


### PR DESCRIPTION
## Summary
- delete evaluation using a database transaction to remove applications first

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a82e312c832b9bafc056ea0ba552