### PR TITLE
Add grade calculation in rubric dialog

### DIFF
--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
@@ -48,7 +48,8 @@
   </div>
 
   <div class="mt-3 text-end">
-    <strong>Puntaje Total: {{ calcularTotal() }}</strong>
+    <strong class="me-3">Puntaje Total: {{ calcularTotal() }}</strong>
+    <span class="badge bg-primary">Nota: {{ calcularNota() }}</span>
   </div>
 
   <div *ngIf="hayErroresDePuntaje()" class="alert alert-warning mt-3">

--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
@@ -94,6 +94,15 @@ export class DialogRubricaEvaluacionComponent implements OnInit {
     return Object.values(this.puntajes).reduce((a, b) => a + (b || 0), 0);
   }
 
+  calcularNota(): number {
+    const totalMax = this.indicadores.reduce(
+      (acc, ind) => acc + ind.Puntaje_Max,
+      0
+    );
+    if (totalMax === 0) return 0;
+    return Math.round((this.calcularTotal() / totalMax) * 100);
+  }
+
   hayErroresDePuntaje(): boolean {
     return this.indicadores.some(i => {
       const val = this.puntajes[i.ID_Indicador];


### PR DESCRIPTION
## Summary
- compute grade based on total points in `DialogRubricaEvaluacionComponent`
- display grade badge next to total score

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bc957904832babc3934f5b44b60f