### PR TITLE
Revamp group cards layout

### DIFF
--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
@@ -48,7 +48,8 @@
   </div>
 
   <div class="mt-3 text-end">
-    <strong>Puntaje Total: {{ calcularTotal() }}</strong>
+    <strong class="me-3">Puntaje Total: {{ calcularTotal() }}</strong>
+    <span class="badge bg-primary">Nota: {{ calcularNota() }}</span>
   </div>
 
   <div *ngIf="hayErroresDePuntaje()" class="alert alert-warning mt-3">

--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
@@ -94,6 +94,15 @@ export class DialogRubricaEvaluacionComponent implements OnInit {
     return Object.values(this.puntajes).reduce((a, b) => a + (b || 0), 0);
   }
 
+  calcularNota(): number {
+    const totalMax = this.indicadores.reduce(
+      (acc, ind) => acc + ind.Puntaje_Max,
+      0
+    );
+    if (totalMax === 0) return 0;
+    return Math.round((this.calcularTotal() / totalMax) * 100);
+  }
+
   hayErroresDePuntaje(): boolean {
     return this.indicadores.some(i => {
       const val = this.puntajes[i.ID_Indicador];

--- a/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.html
+++ b/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.html
@@ -8,37 +8,11 @@
 <!-- Contenedor con scroll solo en el cuerpo -->
 <div class="modal-body" style="max-height: 75vh; overflow-y: auto;">
 
-  <!-- Estado estudiantes -->
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h6 class="fw-bold text-dark mb-0">
-      <i class="bi bi-person-lines-fill me-1"></i> Estado de los Estudiantes
-    </h6>
+  <div class="d-flex justify-content-end mb-3">
     <button class="btn btn-outline-success" (click)="abrirDialogGrupo()" [disabled]="bloqueado">
       <i class="bi bi-people me-1"></i> Crear Grupo
     </button>
   </div>
-
-  <table class="table table-sm table-bordered">
-    <thead class="table-light">
-      <tr>
-        <th>RUT</th>
-        <th>Nombre</th>
-        <th>Apellido</th>
-        <th>Evaluado</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let est of estudiantes">
-        <td>{{ est.ID_Estudiante }}</td>
-        <td>{{ est.Nombre }}</td>
-        <td>{{ est.Apellido }}</td>
-        <td>
-          <i *ngIf="evaluados.has(est.ID_Estudiante)" class="bi bi-check-circle-fill text-success"></i>
-          <i *ngIf="!evaluados.has(est.ID_Estudiante)" class="bi bi-x-circle-fill text-danger"></i>
-        </td>
-      </tr>
-    </tbody>
-  </table>
 
   <!-- Grupos evaluados -->
   <div class="mt-4">
@@ -50,12 +24,14 @@
       Aún no hay grupos evaluados.
     </div>
 
-    <div *ngFor="let grupo of grupos">
-      <div class="border border-success rounded p-3 mb-3 bg-white shadow-sm">
-        <div class="d-flex justify-content-between align-items-center">
-          <div>
+    <div class="row row-cols-1 row-cols-md-3 g-3">
+      <div class="col" *ngFor="let grupo of grupos">
+        <div class="border border-success rounded p-3 h-100 bg-white shadow-sm">
+          <div class="d-flex justify-content-between align-items-center">
+            <div>
             <strong>Grupo {{ grupo.numero }}</strong>
             <span class="text-muted small ms-2">Integrantes: {{ grupo.estudiantes.length }}</span>
+            <span class="badge bg-primary ms-2">Nota: {{ grupo.nota }}</span>
           </div>
 
           <div class="d-flex gap-2">

--- a/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
+++ b/src/app/modules/profesor/evaluaciones/main-evaluacion-detalle/main-evaluacion-detalle/main-evaluacion-detalle.component.ts
@@ -3,8 +3,6 @@ import { CommonModule } from '@angular/common';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { AplicacionService } from '../../../../../services/aplicacion.service';
-import { InscripcionService } from '../../../../../services/inscripcion.service';
-import { Estudiante } from '../../../../../models';
 import { DialogGruposEvaluacionComponent } from '../../dialog-grupos-evaluacion/dialog-grupos-evaluacion/dialog-grupos-evaluacion.component';
 import { DialogRubricaEvaluacionComponent } from '../../dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component';
 
@@ -18,9 +16,8 @@ export class MainEvaluacionDetalleComponent implements OnInit {
   @Input() evaluacionID!: number;
   @Input() asignaturaID!: string;
 
-  estudiantes: any[] = [];
   evaluados: Set<number> = new Set();
-  grupos: { numero: number, estudiantes: any[] }[] = [];
+  grupos: { numero: number, estudiantes: any[], nota: number }[] = [];
 
   mensajeExito = '';
   mensajeError = '';
@@ -31,24 +28,16 @@ export class MainEvaluacionDetalleComponent implements OnInit {
   constructor(
     public modal: NgbActiveModal,
     private aplicacionService: AplicacionService,
-    private inscripcionService: InscripcionService,
     private modalService: NgbModal
   ) {}
 
   ngOnInit(): void {
-    this.cargarEstadoEstudiantes();
+    this.cargarEvaluados();
     this.cargarGrupos();
   }
 
   cancelar() {
     this.modal.dismiss();
-  }
-
-  cargarEstadoEstudiantes() {
-    this.inscripcionService.obtenerPorAsignatura(this.asignaturaID).subscribe((data: Estudiante[]) => {
-      this.estudiantes = data;
-      this.cargarEvaluados();
-    });
   }
 
   cargarEvaluados() {
@@ -59,20 +48,33 @@ export class MainEvaluacionDetalleComponent implements OnInit {
 
   cargarGrupos() {
     this.aplicacionService.obtenerAplicacionesAgrupadas(this.evaluacionID, this.asignaturaID).subscribe((data: any[]) => {
-      const agrupado: { [grupo: number]: any[] } = {};
+      const agrupado: {
+        [grupo: number]: { estudiantes: any[]; total: number; max: number };
+      } = {};
+
       for (const app of data) {
-        if (!agrupado[app.Grupo]) agrupado[app.Grupo] = [];
-        if (!agrupado[app.Grupo].some((e: any) => e.ID_Estudiante === app.ID_Estudiante)) {
-          agrupado[app.Grupo].push({
+        if (!agrupado[app.Grupo]) {
+          agrupado[app.Grupo] = { estudiantes: [], total: 0, max: 0 };
+        }
+
+        if (!agrupado[app.Grupo].estudiantes.some((e: any) => e.ID_Estudiante === app.ID_Estudiante)) {
+          agrupado[app.Grupo].estudiantes.push({
             ID_Estudiante: app.ID_Estudiante,
             Nombre: app.Nombre,
             Apellido: app.Apellido
           });
         }
+
+        agrupado[app.Grupo].total += app.Obtenido;
+        agrupado[app.Grupo].max += app.Puntaje_Max;
       }
 
       this.grupos = Object.keys(agrupado)
-        .map(g => ({ numero: +g, estudiantes: agrupado[+g] }))
+        .map(g => ({
+          numero: +g,
+          estudiantes: agrupado[+g].estudiantes,
+          nota: agrupado[+g].max ? Math.round((agrupado[+g].total / agrupado[+g].max) * 100) : 0
+        }))
         .sort((a, b) => a.numero - b.numero);
     });
   }

--- a/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.html
+++ b/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.html
@@ -1,12 +1,13 @@
-<div class="card shadow-sm border-start border-4 border-success mb-3">
+<div class="card shadow-sm border-start border-4 border-success mb-3 h-100">
   <div class="card-body">
     <div class="d-flex justify-content-between align-items-center">
       <div>
-<h6 class="fw-bold text-success mb-2 d-flex align-items-center">
-  <i class="bi bi-people-fill me-2"></i>
-  Grupo {{ numero }}
-  <i *ngIf="grupoEvaluado" class="bi bi-check-circle-fill text-success ms-2" title="Grupo evaluado"></i>
-</h6>
+        <h6 class="fw-bold text-success mb-2 d-flex align-items-center">
+          <i class="bi bi-people-fill me-2"></i>
+          Grupo {{ numero }}
+          <i *ngIf="grupoEvaluado" class="bi bi-check-circle-fill text-success ms-2" title="Grupo evaluado"></i>
+          <span *ngIf="nota !== null" class="badge bg-primary ms-2">{{ nota }}</span>
+        </h6>
 
         <p class="mb-0 small text-muted">Integrantes: {{ estudiantes.length }}</p>
       </div>

--- a/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
+++ b/src/app/modules/profesor/evaluaciones/tarjeta-grupo/tarjeta-grupo.component.ts
@@ -16,6 +16,7 @@ export class TarjetaGrupoComponent {
   @Input() nombreGrupo: string = '';
   @Input() numero!: number;
   @Input() evaluados: Set<number> = new Set();
+  @Input() nota: number | null = null;
 
 
   constructor(private modalService: NgbModal) {}


### PR DESCRIPTION
## Summary
- remove student status table from evaluation detail
- display group cards in a responsive grid
- compute grade per group when loading groups
- show grade badge on each group card
- add optional grade input for `TarjetaGrupoComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bc957904832babc3934f5b44b60f