### PR TITLE
Implement Chilean RUT validation and login feedback

### DIFF
--- a/backend/controllers/usuario.controller.js
+++ b/backend/controllers/usuario.controller.js
@@ -3,13 +3,14 @@ const UsuarioService = require('../services/usuario.service');
 // Crear nuevo usuario
 exports.crearUsuario = async (req, res) => {
   const { ID_Usuario, Nombre, Clave, Rol_ID_Rol } = req.body;
+  const rut = ID_Usuario.replace(/\./g, '').replace(/-/g, '').toUpperCase();
 
   if (!ID_Usuario || !Nombre || !Clave || !Rol_ID_Rol) {
     return res.status(400).json({ message: 'Faltan datos requeridos para crear el usuario' });
   }
 
   try {
-    await UsuarioService.crearUsuario(ID_Usuario, Nombre, Clave, Rol_ID_Rol);
+    await UsuarioService.crearUsuario(rut, Nombre, Clave, Rol_ID_Rol);
     res.status(201).json({ message: 'Usuario creado correctamente' });
   } catch (error) {
     console.error(error);
@@ -20,12 +21,16 @@ exports.crearUsuario = async (req, res) => {
 // Validar login
 exports.login = async (req, res) => {
   const { ID_Usuario, Clave } = req.body;
+  const rut = ID_Usuario.replace(/\./g, '').replace(/-/g, '').toUpperCase();
   try {
-    const usuario = await UsuarioService.validarLogin(ID_Usuario, Clave);
-    if (!usuario) {
-      return res.status(401).json({ message: 'Credenciales inválidas' });
+    const resultado = await UsuarioService.validarLogin(rut, Clave);
+    if (resultado?.error === 'not_found') {
+      return res.status(404).json({ message: 'RUT no registrado' });
     }
-    res.json(usuario);
+    if (resultado?.error === 'invalid_password') {
+      return res.status(401).json({ message: 'Clave incorrecta' });
+    }
+    res.json(resultado);
   } catch (error) {
     console.error('Error login backend:', error);
     res.status(500).json({ message: 'Error en el login' });

--- a/backend/services/usuario.service.js
+++ b/backend/services/usuario.service.js
@@ -13,7 +13,7 @@ exports.crearUsuario = async (ID_Usuario, Nombre, Clave, Rol_ID_Rol) => {
   });
 };
 
-// Validar login
+// Validar login y retornar detalle de errores
 exports.validarLogin = (rut, clave) => {
   const sql = `
     SELECT u.ID_Usuario, u.Nombre, u.Clave, r.Nombre AS Rol
@@ -24,11 +24,11 @@ exports.validarLogin = (rut, clave) => {
   return new Promise((resolve, reject) => {
     connection.query(sql, [rut], async (err, results) => {
       if (err) return reject(err);
-      if (results.length === 0) return resolve(null);
+      if (results.length === 0) return resolve({ error: 'not_found' });
 
       const usuario = results[0];
       const match = await bcrypt.compare(clave, usuario.Clave);
-      if (!match) return resolve(null);
+      if (!match) return resolve({ error: 'invalid_password' });
 
       resolve({
         ID_Usuario: usuario.ID_Usuario,

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { UsuarioService } from '../../../../services/usuario.service';
 import { RolService } from '../../../../services/rol.service';
 import { Usuario, Rol } from '../../../../models';
+import { cleanRut, validarRut } from '../../../../utils/rut';
 
 @Component({
   selector: 'app-dialog-usuario',
@@ -82,6 +83,14 @@ export class DialogUsuarioComponent {
       setTimeout(() => (this.mensajeError = ''), 3000);
       return;
     }
+
+    if (!validarRut(this.usuario.ID_Usuario)) {
+      this.mensajeError = 'RUT inválido';
+      setTimeout(() => (this.mensajeError = ''), 3000);
+      return;
+    }
+
+    this.usuario.ID_Usuario = cleanRut(this.usuario.ID_Usuario);
 
     if (!this.accionConfirmada) {
       this.accionConfirmada = 'crear';

--- a/src/app/modules/login/login.component.html
+++ b/src/app/modules/login/login.component.html
@@ -31,6 +31,16 @@
     <button type="submit" class="btn btn-primary btn-lg w-100">ENTRAR</button>
   </form>
 
+  <div *ngIf="mensajeError" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+    <div class="toast show text-bg-danger bg-opacity-75" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          <i class="bi bi-exclamation-octagon-fill me-2"></i>{{ mensajeError }}
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Imagen inferior -->
   <img src="assets/fain.png" alt="FAIN UNACH" class="logo-fain mt-4" />
 </div>

--- a/src/app/modules/login/login.component.ts
+++ b/src/app/modules/login/login.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { UsuarioService } from '../../services/usuario.service';
+import { cleanRut, validarRut } from '../../utils/rut';
 
 @Component({
   selector: 'app-login',
@@ -16,11 +17,19 @@ export class LoginComponent {
     ID_Usuario: '',
     Clave: ''
   };
+  mensajeError = '';
 
   constructor(private usuarioService: UsuarioService, private router: Router) {}
 
   login() {
-    this.usuarioService.login(this.usuario).subscribe({
+    const rut = cleanRut(this.usuario.ID_Usuario);
+    if (!validarRut(rut)) {
+      this.mensajeError = 'RUT inválido';
+      setTimeout(() => (this.mensajeError = ''), 3000);
+      return;
+    }
+
+    this.usuarioService.login({ ID_Usuario: rut, Clave: this.usuario.Clave }).subscribe({
       next: (res: any) => {
         const rol = res?.Rol?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
@@ -33,7 +42,10 @@ export class LoginComponent {
         else if (rol === 'comite curricular') this.router.navigate(['/comite']);
         else alert('⚠️ Rol no reconocido');
       },
-      error: () => alert('❌ Usuario o clave incorrectos')
+      error: (err) => {
+        this.mensajeError = err.error?.message || 'Usuario o clave incorrectos';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
     });
   }
 }

--- a/src/app/utils/rut.ts
+++ b/src/app/utils/rut.ts
@@ -1,0 +1,22 @@
+export function cleanRut(rut: string): string {
+  return rut.replace(/\./g, '').replace(/-/g, '').toUpperCase();
+}
+
+export function validarRut(rut: string): boolean {
+  rut = cleanRut(rut);
+  if (!/^[0-9]+[0-9K]$/.test(rut)) return false;
+  const cuerpo = rut.slice(0, -1);
+  const dv = rut.slice(-1);
+  let sum = 0;
+  let multiplier = 2;
+  for (let i = cuerpo.length - 1; i >= 0; i--) {
+    sum += parseInt(cuerpo.charAt(i), 10) * multiplier;
+    multiplier = multiplier === 7 ? 2 : multiplier + 1;
+  }
+  const expected = 11 - (sum % 11);
+  let dvCalc = '';
+  if (expected === 11) dvCalc = '0';
+  else if (expected === 10) dvCalc = 'K';
+  else dvCalc = expected.toString();
+  return dvCalc === dv;
+}


### PR DESCRIPTION
## Summary
- validate and sanitize RUTs when creating users and logging in
- add login toasts for RUT and password errors
- sanitize RUT and return detailed errors from the API

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843c92f6ac4832ba3204ec37f7f0a56