### PR TITLE
Fix report generation with chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,7 @@ cd backend
 npm install
 ```
 
-If the `pdfkit` package cannot be installed (for example in offline
-environments), the backend will fall back to a minimal built-in PDF
-generator. Reports will render without charts in that case. Install
-`pdfkit` with `npm install pdfkit` to enable full PDF output.
+These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are required to generate reports with charts.
 
 Reports are saved under `backend/uploads/` and returned directly in the
 HTTP response.

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,6 @@
     "mysql2": "^3.14.1",
     "pdfkit": "^0.15.0",
     "docx": "^8.0.0",
-    "quickchart-js": "^4.2.1"
+    "chartjs-node-canvas": "^4.2.2"
   }
 }

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -1,0 +1,32 @@
+const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
+const fs = require('fs');
+const path = require('path');
+
+const width = 800;
+const height = 400;
+const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
+
+async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png') {
+  const config = {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Alumnos sobre promedio (%)',
+        data: datos,
+        backgroundColor: 'rgba(54, 162, 235, 0.6)',
+      }],
+    },
+  };
+
+  const buffer = await chartJSNodeCanvas.renderToBuffer(config);
+  const dir = path.join(__dirname, '..', 'public', 'img');
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const filePath = path.join(dir, nombreArchivo);
+  fs.writeFileSync(filePath, buffer);
+  return filePath;
+}
+
+module.exports = { generarGraficoBarras };

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -1,20 +1,16 @@
 
-let PDFDocument;
-try {
-  PDFDocument = require('pdfkit');
-} catch {
-  PDFDocument = require('./minimalPdfKit');
-  console.warn('pdfkit not found, using minimalPdfKit - charts will be omitted');
-}
-
-let docx;
-try {
-  docx = require('docx');
-} catch {
-  docx = require('./minimalDocx');
-  console.warn('docx package not found, using minimalDocx');
-}
-const { Document, Packer, Paragraph, HeadingLevel, Table, TableRow, TableCell, TextRun, Media } = docx;
+const PDFDocument = require('pdfkit');
+const fs = require('fs');
+const {
+  Document,
+  Packer,
+  Paragraph,
+  HeadingLevel,
+  Table,
+  TableRow,
+  TableCell,
+  ImageRun,
+} = require('docx');
 
 // Genera un PDF básico a partir del contenido entregado
 exports.generarPDF = contenido => {
@@ -86,9 +82,8 @@ exports.generarPDFCompleto = contenido => {
     });
 
 
-    if (contenido.chartImage) {
-      doc.image(contenido.chartImage, { fit: [500, 300], align: 'center' });
-
+    if (contenido.chartPath) {
+      doc.image(contenido.chartPath, { width: 500 });
       doc.moveDown();
     }
 
@@ -166,7 +161,16 @@ exports.generarDOCXCompleto = contenido => {
           tableIndicadores,
           ...contenido.analisis.map(a => new Paragraph(a)),
 
-          contenido.chartImage ? Media.addImage(doc, contenido.chartImage) : new Paragraph(''),
+          contenido.chartPath
+            ? new Paragraph({
+                children: [
+                  new ImageRun({
+                    data: fs.readFileSync(contenido.chartPath),
+                    transformation: { width: 500, height: 250 },
+                  }),
+                ],
+              })
+            : new Paragraph(''),
 
           new Paragraph({ text: 'Cumplimiento por Competencia', heading: HeadingLevel.HEADING_2 }),
           compTable,


### PR DESCRIPTION
## Summary
- add grafico.js utility using `chartjs-node-canvas`
- update reportGenerator to use pdfkit and docx directly and embed chart
- update informe service to create charts using new utility
- remove `quickchart-js` dependency and add `chartjs-node-canvas`
- document required backend packages and keep image folder

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in project root *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684536b59bcc832bb1a2fc943efe4ded