### PR TITLE
Fix env handling and doc install tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd backend
 npm install
 # If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
 # npm install pdfkit docx chartjs-node-canvas
+# On Linux you may also need development headers for the `canvas` package:
+# sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
 node app.js
 ```
 
@@ -96,6 +98,8 @@ cd backend
 npm install
 # If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
 # npm install pdfkit docx chartjs-node-canvas
+# On Linux you may also need development headers for the `canvas` package:
+# sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
 ```
 
 These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are required to generate reports with charts.

--- a/backend/.env
+++ b/backend/.env
@@ -3,4 +3,4 @@ DB_USER=root
 DB_PASSWORD=           # ← si no tienes contraseña, déjalo vacío
 DB_NAME=HitoAI
 PORT=3000
-OPENAI_KEY=sk-proj-GznLKfiW7SV3JIXLOUC-jPNQLSM-obg1RqpG7evvy5x0DkfqHJ4yг6OKABQbGG_DjDUgEhpwz0T3BIbkFJ9_6-YuJ3WQDZIg3a71A0mdF7D7CnUOR7GmKBb0-TO7SuXwk|7Bomz-IgExeYoj0ulP55vCB8A
+OPENAI_KEY=

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env


### PR DESCRIPTION
## Summary
- stop tracking backend environment variables
- document Linux build dependencies for chartjs-node-canvas

## Testing
- `npm test` *(fails: ng not found)*
- `(cd backend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68453d83a66c832bba49f0c2291935a9