### PR TITLE
Handle missing pdfkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are
 Reports are saved under `backend/uploads/` and returned directly in the
 HTTP response.
 
+### Troubleshooting
+
+If you see an error like `Cannot find module 'pdfkit'` when starting the
+backend, install the missing dependencies inside `backend/`:
+
+```bash
+cd backend
+npm install pdfkit docx chartjs-node-canvas
+```
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -102,13 +102,18 @@ exports.generarInforme = async asignaturaId => {
     chartPath,
   };
 
-  const pdf = await generarPDFCompleto(contenido);
+  let pdf = Buffer.from('');
+  try {
+    pdf = await generarPDFCompleto(contenido);
+  } catch (err) {
+    console.warn('PDF generation skipped:', err.message);
+  }
   const docx = await generarDOCXCompleto(contenido);
 
   const base = `Informe-${asignatura.Nombre}-${new Date().toISOString().split('T')[0]}`.replace(/\s+/g, '_');
   const outDir = path.join(__dirname, '..', 'uploads');
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
-  fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
+  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
   fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   if (fs.existsSync(chartPath)) fs.unlinkSync(chartPath);
   return { pdf, nombre: `${base}.pdf` };

--- a/backend/services/reporte.service.js
+++ b/backend/services/reporte.service.js
@@ -22,12 +22,18 @@ exports.generarReporte = async asignaturaId => {
   const introduccion = await crearIntroduccion(datos.Nombre);
   const conclusion = await crearConclusion(datos.Nombre);
   const contenido = { datos, introduccion, conclusion };
-  const pdf = await generarPDF(contenido);
+  let pdf = Buffer.from('');
+  try {
+    pdf = await generarPDF(contenido);
+  } catch (err) {
+    console.warn('PDF generation skipped:', err.message);
+  }
   const docx = await generarDOCX(contenido);
 
   const base = `Informe-${datos.ID_Asignatura}-${new Date().toISOString().split('T')[0]}`;
   const outDir = path.join(__dirname, '..', 'uploads');
-  fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
   fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   return pdf;
 };

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -1,5 +1,13 @@
 
-const PDFDocument = require('pdfkit');
+let PDFDocument;
+try {
+  PDFDocument = require('pdfkit');
+} catch (err) {
+  console.warn(
+    'pdfkit module not found. Run "npm install" in the backend directory to enable PDF generation.'
+  );
+  PDFDocument = null;
+}
 const fs = require('fs');
 const {
   Document,
@@ -14,6 +22,9 @@ const {
 
 // Genera un PDF básico a partir del contenido entregado
 exports.generarPDF = contenido => {
+  if (!PDFDocument) {
+    return Promise.reject(new Error('pdfkit not installed'));
+  }
   return new Promise(resolve => {
     const doc = new PDFDocument();
     const chunks = [];
@@ -60,6 +71,9 @@ exports.generarDOCX = contenido => {
 
 // Genera un PDF completo con tablas y gráfico
 exports.generarPDFCompleto = contenido => {
+  if (!PDFDocument) {
+    return Promise.reject(new Error('pdfkit not installed'));
+  }
   return new Promise(resolve => {
     const doc = new PDFDocument({ margin: 40 });
     const chunks = [];


### PR DESCRIPTION
## Summary
- warn if `pdfkit` isn't installed and skip PDF output
- make PDF generation optional in report services
- document how to install the missing modules

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845413a2370832bad169a0bfbfcf219