### PR TITLE
Handle missing pdfkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Install dependencies and start the API server:
 cd backend
 npm install
 # If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
-# npm install pdfkit docx chartjs-node-canvas
+# npm install pdfkit docx chartjs-node-canvas@latest
+# If you hit "No matching version" errors for chartjs-node-canvas, try:
+# npm install chartjs-node-canvas@latest
 # On Linux you may also need development headers for the `canvas` package:
 # sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
 node app.js
@@ -97,7 +99,7 @@ dependencies before running the server:
 cd backend
 npm install
 # If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
-# npm install pdfkit docx chartjs-node-canvas
+# npm install pdfkit docx chartjs-node-canvas@latest
 # On Linux you may also need development headers for the `canvas` package:
 # sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
 ```
@@ -106,6 +108,24 @@ These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are
 
 Reports are saved under `backend/uploads/` and returned directly in the
 HTTP response.
+
+### Troubleshooting
+
+If you see an error like `Cannot find module 'pdfkit'` when starting the
+backend, install the missing dependencies inside `backend/`:
+
+```bash
+cd backend
+npm install pdfkit docx chartjs-node-canvas@latest
+```
+
+If `npm install` fails with a message like `No matching version found for chartjs-node-canvas@^4.2.2`,
+install the latest version explicitly:
+
+```bash
+cd backend
+npm install chartjs-node-canvas@latest
+```
 
 ## Additional Resources
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,6 @@
     "mysql2": "^3.14.1",
     "pdfkit": "^0.15.0",
     "docx": "^8.0.0",
-    "chartjs-node-canvas": "^4.2.2"
+    "chartjs-node-canvas": "^4.3.0"
   }
 }

--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -102,14 +102,24 @@ exports.generarInforme = async asignaturaId => {
     chartPath,
   };
 
-  const pdf = await generarPDFCompleto(contenido);
-  const docx = await generarDOCXCompleto(contenido);
+  let pdf = Buffer.from('');
+  try {
+    pdf = await generarPDFCompleto(contenido);
+  } catch (err) {
+    console.warn('PDF generation skipped:', err.message);
+  }
+  let docx = Buffer.from('');
+  try {
+    docx = await generarDOCXCompleto(contenido);
+  } catch (err) {
+    console.warn('DOCX generation skipped:', err.message);
+  }
 
   const base = `Informe-${asignatura.Nombre}-${new Date().toISOString().split('T')[0]}`.replace(/\s+/g, '_');
   const outDir = path.join(__dirname, '..', 'uploads');
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
-  fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
-  fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
+  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
+  if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   if (fs.existsSync(chartPath)) fs.unlinkSync(chartPath);
   return { pdf, nombre: `${base}.pdf` };
 };

--- a/backend/services/reporte.service.js
+++ b/backend/services/reporte.service.js
@@ -22,12 +22,23 @@ exports.generarReporte = async asignaturaId => {
   const introduccion = await crearIntroduccion(datos.Nombre);
   const conclusion = await crearConclusion(datos.Nombre);
   const contenido = { datos, introduccion, conclusion };
-  const pdf = await generarPDF(contenido);
-  const docx = await generarDOCX(contenido);
+  let pdf = Buffer.from('');
+  try {
+    pdf = await generarPDF(contenido);
+  } catch (err) {
+    console.warn('PDF generation skipped:', err.message);
+  }
+  let docx = Buffer.from('');
+  try {
+    docx = await generarDOCX(contenido);
+  } catch (err) {
+    console.warn('DOCX generation skipped:', err.message);
+  }
 
   const base = `Informe-${datos.ID_Asignatura}-${new Date().toISOString().split('T')[0]}`;
   const outDir = path.join(__dirname, '..', 'uploads');
-  fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
-  fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
+  if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   return pdf;
 };

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -1,19 +1,44 @@
 
-const PDFDocument = require('pdfkit');
+let PDFDocument;
+try {
+  PDFDocument = require('pdfkit');
+} catch (err) {
+  console.warn(
+    'pdfkit module not found. Run "npm install" in the backend directory to enable PDF generation.'
+  );
+  PDFDocument = null;
+}
 const fs = require('fs');
-const {
-  Document,
+let Document,
   Packer,
   Paragraph,
   HeadingLevel,
   Table,
   TableRow,
   TableCell,
-  ImageRun,
-} = require('docx');
+  ImageRun;
+try {
+  ({
+    Document,
+    Packer,
+    Paragraph,
+    HeadingLevel,
+    Table,
+    TableRow,
+    TableCell,
+    ImageRun,
+  } = require('docx'));
+} catch (err) {
+  console.warn(
+    'docx module not found. Run "npm install" in the backend directory to enable DOCX generation.'
+  );
+}
 
 // Genera un PDF básico a partir del contenido entregado
 exports.generarPDF = contenido => {
+  if (!PDFDocument) {
+    return Promise.reject(new Error('pdfkit not installed'));
+  }
   return new Promise(resolve => {
     const doc = new PDFDocument();
     const chunks = [];
@@ -34,6 +59,9 @@ exports.generarPDF = contenido => {
 
 // Genera un DOCX con la misma información
 exports.generarDOCX = contenido => {
+  if (!Document) {
+    return Promise.reject(new Error('docx not installed'));
+  }
   const doc = new Document({
     sections: [
       {
@@ -60,6 +88,9 @@ exports.generarDOCX = contenido => {
 
 // Genera un PDF completo con tablas y gráfico
 exports.generarPDFCompleto = contenido => {
+  if (!PDFDocument) {
+    return Promise.reject(new Error('pdfkit not installed'));
+  }
   return new Promise(resolve => {
     const doc = new PDFDocument({ margin: 40 });
     const chunks = [];
@@ -104,6 +135,9 @@ exports.generarPDFCompleto = contenido => {
 
 // Genera un DOCX completo similar al PDF
 exports.generarDOCXCompleto = contenido => {
+  if (!Document) {
+    return Promise.reject(new Error('docx not installed'));
+  }
   const tableIndicadores = new Table({
     rows: [
       new TableRow({


### PR DESCRIPTION
## Summary
- warn if `pdfkit` isn't installed and skip PDF output
- warn if `docx` isn't installed and skip DOCX output
- make PDF/DOCX generation optional in report services
- bump `chartjs-node-canvas` version so `npm install` works
- document fallback install instructions

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845413a2370832bad169a0bfbfcf219