### PR TITLE
Handle missing PDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are
 Reports are saved under `backend/uploads/` and the API returns a ZIP file
 containing both the PDF and Word versions.
 
+If `pdfkit` is not installed, the generated ZIP will only include the Word
+document because the PDF cannot be created. Make sure all optional
+dependencies are installed if you need the PDF output.
+
 ### Troubleshooting
 
 If you see an error like `Cannot find module 'pdfkit'` when starting the

--- a/backend/controllers/informe.controller.js
+++ b/backend/controllers/informe.controller.js
@@ -3,10 +3,18 @@ const InformeService = require('../services/informe.service');
 exports.generar = async (req, res) => {
   const { asignaturaId } = req.params;
   try {
-    const { pdf, docx, nombre, nombreDocx } = await InformeService.generarInforme(asignaturaId);
-    const zip = require('jszip')();
+  const { pdf, docx, nombre, nombreDocx } = await InformeService.generarInforme(asignaturaId);
+  const zip = require('jszip')();
+  if (pdf && pdf.length) {
     zip.file(nombre, pdf);
+  } else {
+    console.warn('PDF not included in ZIP: generation failed or dependency missing');
+  }
+  if (docx && docx.length) {
     zip.file(nombreDocx, docx);
+  } else {
+    console.warn('DOCX not included in ZIP: generation failed or dependency missing');
+  }
     const buffer = await zip.generateAsync({ type: 'nodebuffer' });
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader('Content-Disposition', `attachment; filename=Informe-${asignaturaId}.zip`);


### PR DESCRIPTION
## Summary
- avoid empty PDFs in report zip files
- document dependency requirements to generate PDF output

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845518c65f4832badc476d3e124ecde