### PR TITLE
Add performance distribution tables per evaluation instance

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -146,6 +146,10 @@ exports.generarInforme = async asignaturaId => {
       porcentaje: Math.round((r.cantidad / r.total) * 1000) / 10,
     });
   });
+  // Ordenar criterios de cada indicador por rango máximo descendente
+  Object.keys(rubricaMap).forEach(k => {
+    rubricaMap[k].sort((a, b) => b.rMax - a.rMax);
+  });
 
   // Agrupar por instancia
   const instancias = {};


### PR DESCRIPTION
## Summary
- sort rubric criteria by score range
- build dynamic distribution tables for PDF and DOCX reports
- insert these tables after indicator analysis for each instance

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff234e6c832bbbfe541c7654ea0e