### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ThemeService } from './services/theme.service';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
@@ -9,4 +10,6 @@ import { RouterOutlet } from '@angular/router';
 })
 export class AppComponent {
   title = 'HitoAI';
+
+  constructor(public themeService: ThemeService) {}
 }

--- a/src/app/modules/login/login.component.css
+++ b/src/app/modules/login/login.component.css
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 }
 
 .logo-unach {
@@ -47,4 +48,10 @@
 }
 
 .toast { font-size: 1rem; }
+
+.theme-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
 

--- a/src/app/modules/login/login.component.html
+++ b/src/app/modules/login/login.component.html
@@ -1,4 +1,7 @@
 <div class="login-container text-center">
+  <button type="button" class="btn btn-outline-secondary theme-toggle" (click)="toggleTheme()">
+    <i class="bi" [ngClass]="themeService.isDarkMode() ? 'bi-brightness-high' : 'bi-moon-fill'"></i>
+  </button>
   <!-- Imagen superior -->
   <img src="assets/unach3.png" alt="Logo UNACH" class="logo-unach" />
 

--- a/src/app/modules/login/login.component.ts
+++ b/src/app/modules/login/login.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { UsuarioService } from '../../services/usuario.service';
 import { MensajeService } from '../../services/mensaje.service';
+import { ThemeService } from '../../services/theme.service';
 import { cleanRut, validarRut } from '../../utils/rut';
 
 @Component({
@@ -27,7 +28,8 @@ export class LoginComponent {
   constructor(
     private usuarioService: UsuarioService,
     private mensajeService: MensajeService,
-    private router: Router
+    private router: Router,
+    public themeService: ThemeService
   ) {}
 
   login() {
@@ -79,5 +81,9 @@ export class LoginComponent {
       }
 
     });
+  }
+
+  toggleTheme() {
+    this.themeService.toggleDarkMode();
   }
 }

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private darkMode = false;
+
+  constructor() {
+    const stored = localStorage.getItem('darkMode');
+    this.darkMode = stored === 'true';
+    this.applyTheme();
+  }
+
+  isDarkMode(): boolean {
+    return this.darkMode;
+  }
+
+  toggleDarkMode(): void {
+    this.darkMode = !this.darkMode;
+    localStorage.setItem('darkMode', String(this.darkMode));
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    if (this.darkMode) {
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+  }
+}

--- a/src/app/shared/components/sidebar/sidebar.component.css
+++ b/src/app/shared/components/sidebar/sidebar.component.css
@@ -23,3 +23,8 @@
   background-color: #0062C4;
   color: #ffffff !important;
 }
+
+.btn-outline-light {
+  color: #ffffff;
+  border-color: #ffffff;
+}

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -90,8 +90,12 @@
     </ng-container>
   </ul>
 
-  <!-- Botón de cerrar sesión -->
+  <!-- Botones inferiores -->
   <div class="mt-auto pt-4">
+    <button type="button" class="btn btn-sm w-100 mb-2 btn-outline-light" (click)="toggleTheme()">
+      <i class="bi" [ngClass]="themeService.isDarkMode() ? 'bi-brightness-high' : 'bi-moon-fill'"></i>
+      <span class="ms-1">Modo Oscuro</span>
+    </button>
     <button class="btn btn-sm w-100 text-white" style="background-color: #0051A2;" (click)="cerrarSesion()">
       Cerrar Sesión
     </button>

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { Router } from '@angular/router';
+import { ThemeService } from '../../../services/theme.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -11,8 +12,12 @@ import { Router } from '@angular/router';
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent {
-  constructor(private router: Router) {}
+  constructor(private router: Router, public themeService: ThemeService) {}
   @Input() rol: string = '';
+
+  toggleTheme() {
+    this.themeService.toggleDarkMode();
+  }
 
 cerrarSesion() {
   localStorage.clear(); // o sessionStorage.clear();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,24 @@
 /* You can add global styles to this file, and also import other style files */
+
+body.dark-mode {
+  background-color: #2e2e2e;
+  color: #e2e2e2;
+}
+
+body.dark-mode a {
+  color: #9ecbff;
+}
+
+body.dark-mode .sidebar {
+  background-color: #1b1b1b !important;
+}
+
+body.dark-mode .form-control {
+  background-color: #454545;
+  color: #ffffff;
+  border-color: #666666;
+}
+
+body.dark-mode .btn-primary {
+  background-color: #0d6efd;
+}


### PR DESCRIPTION
## Summary
- add `ThemeService` to manage dark mode
- apply dark mode styles globally
- enable dark mode toggle in login page
- enable dark mode toggle in sidebar
- initialise theme service in app component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684608a77a00832ba9667447b53add65