### PR TITLE
Fix dark mode grid backgrounds

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -54,3 +54,30 @@ body.dark-mode .text-dark {
   color: #ffffff !important;
 }
 
+/* Button overrides for dark mode */
+body.dark-mode .btn-outline-dark,
+body.dark-mode .btn-outline-secondary {
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
+body.dark-mode .btn-outline-dark:hover,
+body.dark-mode .btn-outline-secondary:hover {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+/* Table grid styles */
+body.dark-mode table {
+  color: #ffffff;
+  background-color: #2e2e2e;
+}
+
+body.dark-mode table thead {
+  background-color: #2b2b2b;
+  color: #ffffff;
+}
+
+body.dark-mode table tbody tr:hover {
+  background-color: #383838;
+}


### PR DESCRIPTION
## Summary
- ensure tables use dark background colors when dark mode is active

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461dbe9854832ba953119747e6f55a