### PR TITLE
Show logged user info in sidebar

### DIFF
--- a/src/app/modules/login/login.component.ts
+++ b/src/app/modules/login/login.component.ts
@@ -46,6 +46,7 @@ export class LoginComponent {
 
         localStorage.setItem('rol', res.Rol);
         localStorage.setItem('rut', res.ID_Usuario); // En el futuro puedes cambiar 'rut' por 'usuario' si prefieres
+        localStorage.setItem('nombre', res.Nombre);
 
         if (rol === 'administrador') this.router.navigate(['/admin']);
         else if (rol === 'jefe de carrera') this.router.navigate(['/jefe-carrera']);

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,34 +1,43 @@
 <div class="sidebar p-3 d-flex flex-column" style="width: 240px; min-height: 100vh; background-color: #001E3B;">
-  <h5 class="text-white mb-4">{{ rol }}</h5>
+  <div class="text-white text-center mb-4">
+    <i class="bi bi-person-circle fs-2"></i>
+    <div class="fw-bold">{{ nombre }}</div>
+    <small>{{ rol }}</small>
+  </div>
 
   <ul class="nav flex-column gap-1">
     <!-- ADMINISTRADOR -->
 <ng-container *ngIf="rol === 'Administrador'">
-  <li class="nav-item">
-    <a class="nav-link text-navbar"
-       routerLink="/admin"
-       routerLinkActive="active"
-       [routerLinkActiveOptions]="{ exact: true }">Inicio</a>
-  </li>
+    <li class="nav-item">
+      <a class="nav-link text-navbar"
+         routerLink="/admin"
+         routerLinkActive="active"
+         [routerLinkActiveOptions]="{ exact: true }">
+         <i class="bi bi-house-door-fill me-1"></i>Inicio</a>
+    </li>
   <li class="nav-item">
     <a class="nav-link text-navbar"
        routerLink="/admin/carreras"
-       routerLinkActive="active">Carreras</a>
+       routerLinkActive="active">
+       <i class="bi bi-mortarboard-fill me-1"></i>Carreras</a>
   </li>
   <li class="nav-item">
     <a class="nav-link text-navbar"
        routerLink="/admin/asignaturas"
-       routerLinkActive="active">Asignaturas</a> <!-- ✅ agregado -->
+       routerLinkActive="active">
+       <i class="bi bi-book-fill me-1"></i>Asignaturas</a> <!-- ✅ agregado -->
   </li>
   <li class="nav-item">
     <a class="nav-link text-navbar"
        routerLink="/admin/usuarios"
-       routerLinkActive="active">Usuarios</a>
+       routerLinkActive="active">
+       <i class="bi bi-people-fill me-1"></i>Usuarios</a>
   </li>
   <li class="nav-item">
     <a class="nav-link text-navbar"
        routerLink="/admin/solicitudes"
-       routerLinkActive="active">Solicitudes</a>
+       routerLinkActive="active">
+       <i class="bi bi-inbox-fill me-1"></i>Solicitudes</a>
   </li>
 </ng-container>
 
@@ -39,22 +48,26 @@
         <a class="nav-link text-navbar"
            routerLink="/jefe-carrera"
            routerLinkActive="active"
-           [routerLinkActiveOptions]="{ exact: true }">Inicio</a>
+           [routerLinkActiveOptions]="{ exact: true }">
+           <i class="bi bi-house-door-fill me-1"></i>Inicio</a>
       </li>
       <li class="nav-item">
         <a class="nav-link text-navbar"
            routerLink="/jefe-carrera/asignaturas"
-           routerLinkActive="active">Asignaturas Hito</a>
+           routerLinkActive="active">
+           <i class="bi bi-book-fill me-1"></i>Asignaturas Hito</a>
       </li>
       <li class="nav-item">
         <a class="nav-link text-navbar"
            routerLink="/jefe-carrera/ra"
-           routerLinkActive="active">Resultados De Aprendizaje</a>
+           routerLinkActive="active">
+           <i class="bi bi-bar-chart-line-fill me-1"></i>Resultados De Aprendizaje</a>
       </li>
-            <li class="nav-item">
+      <li class="nav-item">
         <a class="nav-link text-navbar"
            routerLink="/jefe-carrera/reportes"
-           routerLinkActive="active">Reportes Perfil De Egreso</a>
+           routerLinkActive="active">
+           <i class="bi bi-file-earmark-text-fill me-1"></i>Reportes Perfil De Egreso</a>
       </li>
     </ng-container>
 
@@ -64,12 +77,14 @@
         <a class="nav-link text-navbar"
            routerLink="/profesor"
            routerLinkActive="active"
-           [routerLinkActiveOptions]="{ exact: true }">Inicio</a>
+           [routerLinkActiveOptions]="{ exact: true }">
+           <i class="bi bi-house-door-fill me-1"></i>Inicio</a>
       </li>
       <li class="nav-item">
   <a class="nav-link text-navbar"
      routerLink="/profesor/asignaturas"
-     routerLinkActive="active">Asignaturas Hito</a>
+     routerLinkActive="active">
+     <i class="bi bi-book-fill me-1"></i>Asignaturas Hito</a>
 </li>
 
     </ng-container>
@@ -80,12 +95,14 @@
         <a class="nav-link text-navbar"
            routerLink="/comite"
            routerLinkActive="active"
-           [routerLinkActiveOptions]="{ exact: true }">Inicio</a>
+           [routerLinkActiveOptions]="{ exact: true }">
+           <i class="bi bi-house-door-fill me-1"></i>Inicio</a>
       </li>
       <li class="nav-item">
         <a class="nav-link text-navbar"
            routerLink="/comite/ra"
-           routerLinkActive="active">Resultados De Aprendizaje</a>
+           routerLinkActive="active">
+           <i class="bi bi-bar-chart-line-fill me-1"></i>Resultados De Aprendizaje</a>
       </li>
     </ng-container>
   </ul>
@@ -97,7 +114,8 @@
       <span class="ms-1">Modo Oscuro</span>
     </button>
     <button class="btn btn-sm w-100 text-white" style="background-color: #0051A2;" (click)="cerrarSesion()">
-      Cerrar Sesión
+      <i class="bi bi-box-arrow-right"></i>
+      <span class="ms-1">Cerrar Sesión</span>
     </button>
   </div>
 </div>

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { Router } from '@angular/router';
@@ -11,9 +11,14 @@ import { ThemeService } from '../../../services/theme.service';
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.css']
 })
-export class SidebarComponent {
+export class SidebarComponent implements OnInit {
   constructor(private router: Router, public themeService: ThemeService) {}
   @Input() rol: string = '';
+  nombre: string = '';
+
+  ngOnInit() {
+    this.nombre = localStorage.getItem('nombre') || '';
+  }
 
   toggleTheme() {
     this.themeService.toggleDarkMode();


### PR DESCRIPTION
## Summary
- store user name in `localStorage` on login
- display logged user name and role in sidebar header
- add bootstrap icons to sidebar links and logout button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684620d36810832ba3ed7505686328c8