### PR TITLE
Improve subject reports view

### DIFF
--- a/src/app/modules/jefe-carrera/reportes/reportes.component.css
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.css
@@ -1,0 +1,19 @@
+/* Estilos para las tarjetas de reportes */
+.report-card {
+  border-left: 4px solid #0d6efd;
+}
+
+body.dark-mode .report-card {
+  background-color: #2e2e2e;
+  color: #ffffff;
+}
+
+body.dark-mode .report-card .btn-outline-primary {
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
+body.dark-mode .report-card .btn-outline-primary:hover {
+  background-color: #ffffff;
+  color: #000000;
+}

--- a/src/app/modules/jefe-carrera/reportes/reportes.component.html
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.html
@@ -1,35 +1,45 @@
 <div class="d-flex">
   <app-sidebar [rol]="'Jefe de Carrera'"></app-sidebar>
-  <div class="flex-grow-1 p-4">
-    <h2>Reportes por Asignatura</h2>
-    <table class="table">
-      <thead>
-        <tr><th>Asignatura</th><th>Acciones</th></tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let a of asignaturas">
-          <td>{{a.Nombre}}</td>
-          <td class="text-end">
-            <div class="dropdown">
-              <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="dropdown">
-                <i class="bi bi-three-dots-vertical"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-end">
-                <li>
-                  <a class="dropdown-item" (click)="descargarWord(a.ID_Asignatura)">
-                    <i class="bi bi-file-earmark-word me-1"></i> Generar Word
-                  </a>
-                </li>
-                <li>
-                  <a class="dropdown-item" (click)="descargarPdf(a.ID_Asignatura)">
-                    <i class="bi bi-file-earmark-pdf me-1"></i> Generar PDF
-                  </a>
-                </li>
-              </ul>
+  <div class="flex-grow-1 p-4" style="background-color: #f4f6fa; min-height: 100vh;">
+    <h2 class="mb-4">
+      <i class="bi bi-bar-chart-fill me-2"></i>Reportes por Asignatura
+    </h2>
+
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+      <div class="col" *ngFor="let a of asignaturas">
+        <div class="card h-100 shadow-sm report-card">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title">
+              <i class="bi bi-graph-up-arrow me-2"></i>Reporte de la Asignatura
+            </h5>
+            <p class="card-text mb-3">
+              <strong>Nombre:</strong> {{ a.Nombre }}<br />
+              <strong>ID:</strong> {{ a.ID_Asignatura }}<br />
+              <strong>Semestre:</strong> {{ a.Semestre }}<br />
+              <strong>Plan:</strong> {{ a.Plan_Academico }}
+            </p>
+            <div class="mt-auto">
+              <div class="dropdown w-100">
+                <button class="btn btn-outline-primary w-100" type="button" data-bs-toggle="dropdown">
+                  📊 Generar Reporte
+                </button>
+                <ul class="dropdown-menu w-100">
+                  <li>
+                    <a class="dropdown-item" (click)="descargarWord(a.ID_Asignatura)">
+                      <i class="bi bi-file-earmark-word me-1"></i> Word
+                    </a>
+                  </li>
+                  <li>
+                    <a class="dropdown-item" (click)="descargarPdf(a.ID_Asignatura)">
+                      <i class="bi bi-file-earmark-pdf me-1"></i> PDF
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- display subject reports in a card layout
- style report cards for dark mode

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684622e4517c832b8cd10b23a78f9c5e