### PR TITLE
Improve dark mode for tables

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -39,6 +39,11 @@ body.dark-mode [style*="#f9f9f9"] {
 body.dark-mode .table-light {
   background-color: #2b2b2b !important;
   color: #ffffff !important;
+  --bs-table-bg: #2b2b2b;
+  --bs-table-striped-bg: #2e2e2e;
+  --bs-table-striped-color: #ffffff;
+  --bs-table-hover-bg: #383838;
+  --bs-table-hover-color: #ffffff;
 }
 
 body.dark-mode .titulo {
@@ -71,6 +76,12 @@ body.dark-mode .btn-outline-secondary:hover {
 body.dark-mode table {
   color: #ffffff;
   background-color: #2e2e2e !important;
+  --bs-table-bg: #2e2e2e;
+  --bs-table-striped-bg: #2b2b2b;
+  --bs-table-striped-color: #ffffff;
+  --bs-table-hover-bg: #383838;
+  --bs-table-hover-color: #ffffff;
+  --bs-table-border-color: #555555;
 }
 
 body.dark-mode table thead {


### PR DESCRIPTION
## Summary
- tweak dark mode table styles so Bootstrap tables switch to dark colors

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462eb8e10c832bb2390684263261dd