### PR TITLE
Add route guard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { AuthGuard } from './guards/auth.guard';
 import { HomeComponent as AdminHome } from './modules/admin/home/home.component';
 import { HomeComponent as JefeHome } from './modules/jefe-carrera/home/home.component';
 import { HomeComponent as ProfesorHome } from './modules/profesor/home/home.component';
@@ -10,60 +11,68 @@ export const routes: Routes = [
   { path: 'login', component: LoginComponent },
 
   // ADMIN
-  { path: 'admin', component: AdminHome },
+  { path: 'admin', component: AdminHome, canActivate: [AuthGuard] },
   {
     path: 'admin/carreras',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/admin/carreras/main-carreras/main-carreras.component')
         .then(m => m.MainCarrerasComponent)
   },
   {
     path: 'admin/asignaturas',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/admin/asignaturas/main-asignaturas/main-asignaturas.component')
         .then(m => m.MainAsignaturasComponent)
   },
   {
     path: 'admin/usuarios',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/admin/usuarios/main-usuarios/main-usuarios.component')
         .then(m => m.MainUsuariosComponent)
   },
 
   // JEFE DE CARRERA
-  { path: 'jefe-carrera', component: JefeHome },
+  { path: 'jefe-carrera', component: JefeHome, canActivate: [AuthGuard] },
   {
     path: 'jefe-carrera/asignaturas',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/rubricas/main-asignaturas-jefe/main-asignaturas-jefe.component')
         .then(m => m.MainAsignaturasJefeComponent)
   },
   {
     path: 'jefe-carrera/reportes',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/jefe-carrera/reportes/reportes.component')
         .then(m => m.ReportesComponent)
   },
   {
     path: 'jefe-carrera/ra',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/competencia-ra/ra-main/ra-main.component')
         .then(m => m.MainRaComponent)
   },
 
   // PROFESOR
-  { path: 'profesor', component: ProfesorHome },
+  { path: 'profesor', component: ProfesorHome, canActivate: [AuthGuard] },
   {
     path: 'profesor/asignaturas',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/rubricas/main-asignaturas-profesor/main-asignaturas-profesor.component')
         .then(m => m.MainAsignaturasProfesorComponent)
   },
 
   // COMITÉ CURRICULAR
-  { path: 'comite', component: ComiteHome },
+  { path: 'comite', component: ComiteHome, canActivate: [AuthGuard] },
   {
     path: 'comite/ra',
+    canActivate: [AuthGuard],
     loadComponent: () =>
       import('./modules/competencia-ra/ra-main/ra-main.component')
         .then(m => m.MainRaComponent)

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    const loggedIn = !!localStorage.getItem('rol');
+    return loggedIn ? true : this.router.parseUrl('/login');
+  }
+}


### PR DESCRIPTION
## Summary
- add auth guard service checking localStorage 'rol'
- protect all app routes with the new guard

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846301d73d4832b9a704391d6d4e30e