### PR TITLE
Add criterion average section

### DIFF
--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -1,12 +1,19 @@
 const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
 const fs = require('fs');
 const path = require('path');
-const ChartDataLabels = require('chartjs-plugin-datalabels');
+let ChartDataLabels;
+try {
+  ChartDataLabels = require('chartjs-plugin-datalabels');
+} catch {
+  ChartDataLabels = null;
+}
 
 const width = 900;
 const height = 500;
 const chartCallback = ChartJS => {
-  ChartJS.register(ChartDataLabels);
+  if (ChartDataLabels) {
+    ChartJS.register(ChartDataLabels);
+  }
 };
 const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height, chartCallback });
 


### PR DESCRIPTION
## Summary
- move per-instance criterion summary tables to a new section after all instances
- suppress message when `chartjs-plugin-datalabels` is missing

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847cb0a1274832b9f419b1bdc4b2500