### PR TITLE
Add criterion averages to distribution report

### DIFF
--- a/backend/services/reporte.service.js
+++ b/backend/services/reporte.service.js
@@ -62,7 +62,12 @@ exports.obtenerDistribucionPorInstancia = asignaturaId => {
       c.R_Min AS rMin,
       c.R_Max AS rMax,
       SUM(a.Obtenido BETWEEN c.R_Min AND c.R_Max) AS cantidad,
-      COUNT(a.ID_Aplicacion) AS total
+      COUNT(a.ID_Aplicacion) AS total,
+      ROUND(AVG(CASE WHEN a.Obtenido BETWEEN c.R_Min AND c.R_Max THEN a.Obtenido END), 1) AS promedio,
+      ROUND(
+        AVG(CASE WHEN a.Obtenido BETWEEN c.R_Min AND c.R_Max THEN a.Obtenido END) / i.Puntaje_Max * 100,
+        1
+      ) AS promedioPct
     FROM evaluacion ev
     JOIN aplicacion a ON ev.ID_Evaluacion = a.evaluacion_ID_Evaluacion
     JOIN inscripcion ins ON ins.ID_Inscripcion = a.inscripcion_ID_Inscripcion
@@ -78,20 +83,20 @@ exports.obtenerDistribucionPorInstancia = asignaturaId => {
       if (err) return reject(err);
 
       const instancias = {};
-      // Agrupar información de conteos y porcentajes por indicador
+      // Agrupar información de promedios y porcentajes por indicador
       rows.forEach(r => {
         if (!instancias[r.instancia]) instancias[r.instancia] = {};
         if (!instancias[r.instancia][r.indicadorId]) {
           instancias[r.instancia][r.indicadorId] = {
             indicador: r.indicador,
-            rangos: {},
+            promedios: {},
             porcentajes: {},
             orden: [],
           };
         }
 
         const data = instancias[r.instancia][r.indicadorId];
-        data.rangos[r.criterio] = r.cantidad;
+        data.promedios[r.criterio] = r.promedio || 0;
         const porcentaje = r.total ? Math.round((r.cantidad / r.total) * 100) : 0;
         data.porcentajes[r.criterio] = porcentaje;
         data.orden.push({ nombre: r.criterio, rMax: r.rMax });
@@ -106,15 +111,15 @@ exports.obtenerDistribucionPorInstancia = asignaturaId => {
             .sort((a, b) => b.rMax - a.rMax)
             .map(o => o.nombre);
 
-          const filaAbs = { criterio: ind.indicador };
+          const filaProm = { criterio: ind.indicador };
           const filaPct = { criterio: `${ind.indicador} (%)` };
 
           orden.forEach(n => {
-            filaAbs[n] = ind.rangos[n] || 0;
+            filaProm[n] = ind.promedios[n] || 0;
             filaPct[n] = ind.porcentajes[n] || 0;
           });
 
-          resultado[instancia].push(filaAbs, filaPct);
+          resultado[instancia].push(filaProm, filaPct);
         }
       }
 


### PR DESCRIPTION
## Summary
- extend SQL query in `obtenerDistribucionPorInstancia` to compute average score per criterio
- store the calculated averages and build table rows with averages and percentages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f30e3474832b87b007220eaa5755