### PR TITLE
Enhance reports with per-instance competency breakdowns

### DIFF
--- a/backend/utils/openai.js
+++ b/backend/utils/openai.js
@@ -98,6 +98,11 @@ exports.recomendacionesCompetencia = (competencia, cumplimiento) => {
   return safe(prompt, `Recomendaciones para ${competencia}`);
 };
 
+exports.analisisCompetencia = ({ competencia, puntajeIdeal, promedio, cumplimiento }) => {
+  const prompt = `Redacta un analisis pedagogico de la competencia ${competencia}. Puntaje ideal ${puntajeIdeal}, promedio ${promedio} y cumplimiento ${cumplimiento} por ciento.`;
+  return safe(prompt, `Analisis de la competencia ${competencia}`);
+};
+
 exports.recomendacionesGenerales = temas => {
   const prompt = `Entrega recomendaciones generales para reforzar los siguientes temas: ${temas}.`;
   return safe(prompt, `Recomendaciones para ${temas}`);


### PR DESCRIPTION
## Summary
- compute competency summaries per evaluation instance
- provide per-competency analysis and recommendations
- include final topic-based recommendations
- remove pie chart generation

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489e6e3e24832bb9045e4c33632e76