### PR TITLE
Ensure vertical orientation for line charts

### DIFF
--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -106,6 +106,7 @@ async function generarGraficoLineas(labels, datos, nombreArchivo = 'lineas.png')
       ],
     },
     options: {
+      indexAxis: 'x',
       scales: {
         y: {
           beginAtZero: true,


### PR DESCRIPTION
## Summary
- set `indexAxis: 'x'` for line chart generation to force vertical bars

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afac7450832b9275e5b2fc2341f1