### PR TITLE
Update docx header text

### DIFF
--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -977,7 +977,7 @@ exports.generarDOCXCompleto = async contenido => {
         alignment: AlignmentType.CENTER,
         children: [
           new TextRun({
-            text: 'UNIVERSIDAD ADVENTISTA DE CHILE',
+            text: 'Universidad Adventista de Chile',
             color: 'FFFFFF',
             bold: true,
           }),


### PR DESCRIPTION
## Summary
- use mixed case text in `generarDOCXCompleto()` header to match reference document

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848be0ea1f4832bb1d39e5299b767f3