### PR TITLE
Add metadata to generated DOCX

### DIFF
--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -24,6 +24,7 @@ let Document,
   Header,
   Footer,
   ShadingType,
+  DocumentProperties,
   Chart,
   ChartType;
 try {
@@ -43,6 +44,9 @@ try {
     Header,
     Footer,
     ShadingType,
+    DocumentProperties,
+    Chart,
+    ChartType,
   } = require('docx'));
 } catch (err) {
   console.warn(
@@ -1013,7 +1017,17 @@ exports.generarDOCXCompleto = async contenido => {
     ],
   });
 
+  const props = new DocumentProperties({
+    title: 'Universidad Adventista de Chile',
+    creator: 'ingenieria civil informática',
+    lastModifiedBy: 'Fabian Pavez',
+    lastPrinted: new Date('2024-07-12T16:57:00Z'),
+    created: new Date('2024-07-09T14:26:00Z'),
+    modified: new Date('2025-06-10T22:29:00Z'),
+  });
+
   const doc = new Document({
+    properties: props,
     sections: [
       {
         headers: { default: header },


### PR DESCRIPTION
## Summary
- import `DocumentProperties` from **docx**
- set title, author and date metadata in `generarDOCXCompleto`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c93adbfc832ba08f4a1671fe1489