### PR TITLE
Sanitize chart input values

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -274,13 +274,13 @@ exports.generarInforme = async asignaturaId => {
 
   const barrasPath = await generarGraficoBarras(
     datos.map(d => d.indicador),
-    datos.map(d => d.porcentaje),
+    datos.map(d => Number(d.porcentaje) || 0),
     'barras.png'
   );
 
   const compPath = await generarGraficoLineas(
     competencias.map(c => c.ID_Competencia),
-    competencias.map(c => c.cumplimiento),
+    competencias.map(c => Number(c.cumplimiento) || 0),
     'competencias.png'
   );
 
@@ -288,7 +288,7 @@ exports.generarInforme = async asignaturaId => {
   for (const [num, inst] of Object.entries(instancias)) {
     graficosInstancias[num] = await generarGraficoBarras(
       inst.criterios.map(c => c.indicador),
-      inst.criterios.map(c => c.porcentaje),
+      inst.criterios.map(c => Number(c.porcentaje) || 0),
       `instancia_${num}.png`
     );
   }

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -19,6 +19,7 @@ const chartCallback = ChartJS => {
 const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height, chartCallback });
 
 async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png') {
+  datos = datos.map(d => Number(d) || 0);
   const wrappedLabels = labels.map(l => l.match(/.{1,15}/g)?.join('\n') || l);
 
   const config = {
@@ -92,6 +93,7 @@ async function generarGraficoTorta(labels, datos, nombreArchivo = 'torta.png') {
 }
 
 async function generarGraficoLineas(labels, datos, nombreArchivo = 'lineas.png') {
+  datos = datos.map(d => Number(d) || 0);
   const wrappedLabels = labels.map(l => l.match(/.{1,15}/g)?.join('\n') || l);
   const config = {
     type: 'bar',


### PR DESCRIPTION
## Summary
- sanitize numeric data when preparing chart arrays
- guard against non-numeric values in chart utility functions

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce0a9bb4832bae3106de7e3c2a70