### PR TITLE
Improve reporte generation

### DIFF
--- a/backend/controllers/reporte.controller.js
+++ b/backend/controllers/reporte.controller.js
@@ -3,11 +3,13 @@ const ReporteService = require('../services/reporte.service');
 exports.generarReporte = async (req, res) => {
   const { asignaturaId } = req.params;
   try {
-    const buffer = await ReporteService.generarReporte(asignaturaId);
-    const date = new Date().toISOString().split('T')[0];
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename=Informe-${asignaturaId}-${date}.pdf`);
-    return res.send(buffer);
+    const { docx, nombreDocx } = await ReporteService.generarReporte(asignaturaId);
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    );
+    res.setHeader('Content-Disposition', `attachment; filename=${nombreDocx}`);
+    return res.send(docx);
   } catch (err) {
     console.error('Error al generar reporte:', err);
     res.status(500).json({ message: 'Error al generar reporte' });

--- a/backend/services/reporte.service.js
+++ b/backend/services/reporte.service.js
@@ -1,54 +1,11 @@
 const connection = require('../db/connection');
-const fs = require('fs');
-const path = require('path');
-const { crearIntroduccion, crearConclusion } = require('../utils/openai');
-const { generarPDF, generarDOCX } = require('../utils/reportGenerator');
+const InformeService = require('./informe.service');
 
-async function obtenerDatos(asignaturaId) {
-  return new Promise(resolve => {
-    const sql = `
-      SELECT a.*, c.Nombre AS Carrera
-      FROM asignatura a
-      JOIN carrera c ON a.carrera_ID_Carrera = c.ID_Carrera
-      WHERE a.ID_Asignatura = ?`;
-    connection.query(sql, [asignaturaId], (err, rows) => {
-      if (err || !rows.length) {
-        console.error('Error obteniendo asignatura', err);
-        return resolve({ ID_Asignatura: asignaturaId, Nombre: `Asignatura ${asignaturaId}` });
-      }
-      resolve(rows[0]);
-    });
-  });
-}
 
 exports.generarReporte = async asignaturaId => {
-  const datos = await obtenerDatos(asignaturaId);
-  const introduccion = await crearIntroduccion(datos.Nombre, datos.Carrera);
-  const conclusion = await crearConclusion(datos.Nombre);
-  const contenido = { datos, introduccion, conclusion };
-  let pdf = Buffer.from('');
-  try {
-    pdf = await generarPDF(contenido);
-  } catch (err) {
-    console.warn('PDF generation skipped:', err.message);
-  }
-
-  let docx = Buffer.from('');
-  try {
-    docx = await generarDOCX(contenido);
-  } catch (err) {
-    console.warn('DOCX generation skipped:', err.message);
-  }
-
-
-  const base = `Informe-${datos.ID_Asignatura}-${new Date().toISOString().split('T')[0]}`;
-  const outDir = path.join(__dirname, '..', 'uploads');
-  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
-  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
-
-  if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
-
-  return pdf;
+  // Delegate to the more complete report generator so the output
+  // includes charts and additional analysis like the reference document.
+  return InformeService.generarInforme(asignaturaId);
 };
 
 // Distribución de puntajes y promedios por instancia e indicador


### PR DESCRIPTION
## Summary
- reuse InformeService in reporte service
- send DOCX output with charts from reporte endpoint

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d2a4d6d0832b8228fb70cfc03cd2