### PR TITLE
Implement RUT validation and enrollment availability

### DIFF
--- a/backend/controllers/estudiante.controller.js
+++ b/backend/controllers/estudiante.controller.js
@@ -12,6 +12,11 @@ exports.getNoInscritos = async (req, res) => {
   res.json(data);
 };
 
+exports.getDisponiblesPorAsignatura = async (req, res) => {
+  const data = await EstudianteService.getDisponiblesPorAsignatura(req.params.id);
+  res.json(data);
+};
+
 exports.crear = async (req, res) => {
   await EstudianteService.crear(req.body);
   res.status(201).json({ message: 'Estudiante creado' });

--- a/backend/routes/estudiante.routes.js
+++ b/backend/routes/estudiante.routes.js
@@ -6,6 +6,7 @@ const upload = multer({ dest: 'uploads/' });
 
 router.get('/', controller.getAll);
 router.get('/no-inscritos', controller.getNoInscritos);
+router.get('/disponibles/:id', controller.getDisponiblesPorAsignatura);
 router.post('/crear', controller.crear);
 router.put('/actualizar/:id', controller.actualizar);
 router.delete('/eliminar/:id', controller.eliminar);

--- a/backend/services/estudiante.service.js
+++ b/backend/services/estudiante.service.js
@@ -19,6 +19,22 @@ exports.getNoInscritos = () => {
   });
 };
 
+exports.getDisponiblesPorAsignatura = (asignaturaId) => {
+  const sql = `
+    SELECT * FROM estudiante e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM inscripcion i
+      WHERE i.estudiante_ID_Estudiante = e.ID_Estudiante
+        AND i.asignatura_ID_Asignatura = ?
+    )
+  `;
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [asignaturaId], (err, results) =>
+      err ? reject(err) : resolve(results)
+    );
+  });
+};
+
 exports.crear = (est) => {
   const sql = `INSERT INTO estudiante (ID_Estudiante, Nombre, Apellido, Anio_Ingreso) VALUES (?, ?, ?, ?)`;
   return new Promise((resolve, reject) => {

--- a/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { EstudianteService } from '../../../../services/estudiante.service';
 import { Estudiante } from '../../../../models';
+import { cleanRut, validarRut } from '../../../../utils/rut';
 
 
 @Component({
@@ -57,6 +58,14 @@ export class DialogFormEstudianteComponent implements OnInit {
       return;
     }
 
+    const rut = cleanRut(this.estudiante.ID_Estudiante);
+    if (!validarRut(rut)) {
+      this.mensajeError = 'RUT inválido';
+      setTimeout(() => this.mensajeError = '', 3000);
+      return;
+    }
+    this.estudiante.ID_Estudiante = rut;
+
     if (!this.accionConfirmada) {
       this.accionConfirmada = 'crear';
       return;
@@ -75,6 +84,14 @@ export class DialogFormEstudianteComponent implements OnInit {
       setTimeout(() => this.mensajeError = '', 3000);
       return;
     }
+
+    const rut = cleanRut(this.estudiante.ID_Estudiante);
+    if (!validarRut(rut)) {
+      this.mensajeError = 'RUT inválido';
+      setTimeout(() => this.mensajeError = '', 3000);
+      return;
+    }
+    this.estudiante.ID_Estudiante = rut;
 
     if (!this.accionConfirmada) {
       this.accionConfirmada = 'actualizar';

--- a/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.ts
@@ -30,11 +30,11 @@ export class DialogInscripcionComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.cargarEstudiantesNoInscritos();
+    this.cargarEstudiantesDisponibles();
   }
 
-  cargarEstudiantesNoInscritos() {
-    this.estudianteService.obtenerNoInscritos().subscribe(data => {
+  cargarEstudiantesDisponibles() {
+    this.estudianteService.obtenerDisponibles(this.asignatura.ID_Asignatura).subscribe(data => {
       this.estudiantes = data.map(e => ({ ...e, seleccionado: false }));
     });
   }

--- a/src/app/services/estudiante.service.ts
+++ b/src/app/services/estudiante.service.ts
@@ -22,6 +22,11 @@ export class EstudianteService {
     return this.http.get<Estudiante[]>(`${this.apiUrl}/no-inscritos`);
   }
 
+  // Obtener estudiantes no inscritos en una asignatura específica
+  obtenerDisponibles(asignaturaId: string): Observable<Estudiante[]> {
+    return this.http.get<Estudiante[]>(`${this.apiUrl}/disponibles/${asignaturaId}`);
+  }
+
   // Crear estudiante
   crear(estudiante: Estudiante): Observable<any> {
     return this.http.post(`${this.apiUrl}/crear`, estudiante);


### PR DESCRIPTION
## Summary
- add API endpoint to list students that are not enrolled in a specific subject
- expose new function in student service to call this endpoint
- update enrollment dialog to use the new service so students can enrol in other subjects but not the same one twice
- validate and sanitize RUT when creating or editing a student

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d1b80130832bbdc9e6d321531a3f