### PR TITLE
Improve RUT handling and display

### DIFF
--- a/backend/controllers/estudiante.controller.js
+++ b/backend/controllers/estudiante.controller.js
@@ -43,7 +43,11 @@ exports.cargarCSV = async (req, res) => {
   fs.createReadStream(archivo.path)
     .pipe(csv())
     .on('data', (row) => {
-      const rut = row?.ID_Estudiante?.toString().replace(/\./g, '').trim();
+      const rut = row?.ID_Estudiante
+        ?.toString()
+        .replace(/\./g, '')
+        .replace(/-/g, '')
+        .trim();
       const nombre = row?.Nombre?.trim();
       const apellido = row?.Apellido?.trim();
       const anio = parseInt(row?.Anio_Ingreso, 10);

--- a/src/app/modules/admin/asignaturas/dialog-asignatura/dialog-asignatura.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-asignatura/dialog-asignatura.component.html
@@ -110,7 +110,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let est of estudiantesInscritos">
-            <td>{{ est.ID_Estudiante }}</td>
+            <td>{{ est.ID_Estudiante | rutFormat }}</td>
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
             <td *ngIf="puedeDesvincular">

--- a/src/app/modules/admin/asignaturas/dialog-asignatura/dialog-asignatura.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-asignatura/dialog-asignatura.component.ts
@@ -8,12 +8,13 @@ import { InscripcionService } from '../../../../services/inscripcion.service';
 import { UsuarioService } from '../../../../services/usuario.service';
 
 import { Asignatura, Carrera, Usuario, Estudiante } from '../../../../models';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 
 
 @Component({
   selector: 'app-dialog-asignatura',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-asignatura.component.html',
   styleUrls: ['./dialog-asignatura.component.css']
 })

--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.html
@@ -38,7 +38,7 @@
         </thead>
         <tbody>
           <tr *ngFor="let est of estudiantes" style="cursor: pointer;">
-            <td>{{ est.ID_Estudiante }}</td>
+            <td>{{ est.ID_Estudiante | rutFormat }}</td>
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
             <td>{{ est.Anio_Ingreso }}</td>

--- a/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-estudiantes/dialog-estudiantes.component.ts
@@ -5,11 +5,12 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { EstudianteService } from '../../../../services/estudiante.service';
 import { DialogFormEstudianteComponent } from '../dialog-form-estudiante/dialog-form-estudiante.component';
 import { Estudiante } from '../../../../models';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 
 @Component({
   selector: 'app-dialog-estudiantes',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-estudiantes.component.html',
   styleUrls: ['./dialog-estudiantes.component.css']
 })
@@ -26,11 +27,11 @@ export class DialogEstudiantesComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.cargarEstudiantesNoInscritos();
+    this.cargarEstudiantes();
   }
 
-  cargarEstudiantesNoInscritos() {
-    this.estudianteService.obtenerNoInscritos().subscribe(data => {
+  cargarEstudiantes() {
+    this.estudianteService.obtenerTodos().subscribe(data => {
       this.estudiantes = data;
     });
   }
@@ -49,7 +50,7 @@ export class DialogEstudiantesComponent implements OnInit {
     modalRef.componentInstance.datos = modo === 'crear' ? null : est;
 
     modalRef.result.then(res => {
-      if (res === 'actualizado') this.cargarEstudiantesNoInscritos();
+      if (res === 'actualizado') this.cargarEstudiantes();
     }).catch(() => {});
   }
 
@@ -60,7 +61,7 @@ export class DialogEstudiantesComponent implements OnInit {
       this.estudianteService.cargarDesdeCSV(archivo).subscribe((resp) => {
         this.mensajeCSV = resp.message || 'Estudiantes cargados';
         this.mostrarToastCSV = true;
-        this.cargarEstudiantesNoInscritos();
+        this.cargarEstudiantes();
 
         setTimeout(() => this.mostrarToastCSV = false, 3000);
       });

--- a/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.html
@@ -91,7 +91,7 @@
 
   <!-- Vista solo lectura -->
   <div *ngIf="modo === 'ver'">
-    <p><strong>RUT:</strong> {{ estudiante.ID_Estudiante }}</p>
+    <p><strong>RUT:</strong> {{ estudiante.ID_Estudiante | rutFormat }}</p>
     <p><strong>Nombre:</strong> {{ estudiante.Nombre }}</p>
     <p><strong>Apellido:</strong> {{ estudiante.Apellido }}</p>
     <p><strong>Año de Ingreso:</strong> {{ estudiante.Anio_Ingreso }}</p>

--- a/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
@@ -5,12 +5,13 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { EstudianteService } from '../../../../services/estudiante.service';
 import { Estudiante } from '../../../../models';
 import { cleanRut, validarRut } from '../../../../utils/rut';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 
 
 @Component({
   selector: 'app-dialog-form-estudiante',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-form-estudiante.component.html',
   styleUrls: ['./dialog-form-estudiante.component.css']
 })

--- a/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.html
+++ b/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.html
@@ -29,7 +29,7 @@
             <td>
               <input type="checkbox" [(ngModel)]="est.seleccionado" />
             </td>
-            <td>{{ est.ID_Estudiante }}</td>
+            <td>{{ est.ID_Estudiante | rutFormat }}</td>
             <td>{{ est.Nombre }}</td>
             <td>{{ est.Apellido }}</td>
           </tr>

--- a/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-inscripcion/dialog-inscripcion.component.ts
@@ -5,12 +5,13 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { EstudianteService } from '../../../../services/estudiante.service';
 import { InscripcionService } from '../../../../services/inscripcion.service';
 import { Asignatura, Estudiante, Inscripcion } from '../../../../models';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 
 
 @Component({
   selector: 'app-dialog-inscripcion',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-inscripcion.component.html',
   styleUrls: ['./dialog-inscripcion.component.css']
 })

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
@@ -43,7 +43,7 @@
   <div *ngIf="modo !== 'crear'">
     <div class="mb-3">
       <label class="form-label">RUT</label>
-      <input type="text" class="form-control" [value]="usuario.ID_Usuario" disabled />
+      <input type="text" class="form-control" [value]="usuario.ID_Usuario | rutFormat" disabled />
     </div>
     <div class="mb-3">
       <label class="form-label">Nombre</label>

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
@@ -6,12 +6,13 @@ import { UsuarioService } from '../../../../services/usuario.service';
 import { RolService } from '../../../../services/rol.service';
 import { Usuario, Rol } from '../../../../models';
 import { cleanRut, validarRut } from '../../../../utils/rut';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 import { claveSegura } from '../../../../utils/clave';
 
 @Component({
   selector: 'app-dialog-usuario',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-usuario.component.html',
   styleUrls: ['./dialog-usuario.component.css']
 })

--- a/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.html
+++ b/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.html
@@ -29,7 +29,7 @@
             </thead>
             <tbody>
               <tr *ngFor="let u of grupo.usuarios">
-                <td>{{ u.ID_Usuario }}</td>
+                <td>{{ u.ID_Usuario | rutFormat }}</td>
                 <td>{{ u.Nombre }}</td>
                 <td class="text-end">
                   <div class="dropdown">

--- a/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.ts
+++ b/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.ts
@@ -5,11 +5,12 @@ import { UsuarioService } from '../../../../services/usuario.service';
 import { Usuario } from '../../../../models';
 import { SidebarComponent } from '../../../../shared/components/sidebar/sidebar.component';
 import { DialogUsuarioComponent } from '../dialog-usuario/dialog-usuario.component';
+import { RutFormatPipe } from '../../../../pipes/rut-format.pipe';
 
 @Component({
   selector: 'app-main-usuarios',
   standalone: true,
-  imports: [CommonModule, NgbModalModule, SidebarComponent],
+  imports: [CommonModule, NgbModalModule, SidebarComponent, RutFormatPipe],
   templateUrl: './main-usuarios.component.html',
   styleUrls: ['./main-usuarios.component.css']
 })

--- a/src/app/modules/profesor/evaluaciones/dialog-grupos-evaluacion/dialog-grupos-evaluacion/dialog-grupos-evaluacion.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-grupos-evaluacion/dialog-grupos-evaluacion/dialog-grupos-evaluacion.component.html
@@ -26,7 +26,7 @@
           [checked]="seleccionados.has(est.ID_Estudiante)"
           (change)="toggleSeleccion(est.ID_Estudiante)"
         />
-        {{ est.Nombre }} {{ est.Apellido }} <span class="text-muted">({{ est.ID_Estudiante }})</span>
+        {{ est.Nombre }} {{ est.Apellido }} <span class="text-muted">({{ est.ID_Estudiante | rutFormat }})</span>
       </div>
       <span *ngIf="bloqueados.has(est.ID_Estudiante)" class="badge bg-secondary">En un grupo</span>
     </li>

--- a/src/app/modules/profesor/evaluaciones/dialog-grupos-evaluacion/dialog-grupos-evaluacion/dialog-grupos-evaluacion.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-grupos-evaluacion/dialog-grupos-evaluacion/dialog-grupos-evaluacion.component.ts
@@ -5,11 +5,12 @@ import { AplicacionService } from '../../../../../services/aplicacion.service';
 import { InscripcionService } from '../../../../../services/inscripcion.service';
 import { Estudiante } from '../../../../../models';
 import { FormsModule } from '@angular/forms';
+import { RutFormatPipe } from '../../../../../pipes/rut-format.pipe';
 
 @Component({
   selector: 'app-dialog-grupos-evaluacion',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RutFormatPipe],
   templateUrl: './dialog-grupos-evaluacion.component.html'
 })
 export class DialogGruposEvaluacionComponent implements OnInit {

--- a/src/app/pipes/rut-format.pipe.ts
+++ b/src/app/pipes/rut-format.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatRut } from '../utils/rut';
+
+@Pipe({
+  name: 'rutFormat',
+  standalone: true
+})
+export class RutFormatPipe implements PipeTransform {
+  transform(value: string | null | undefined): string {
+    return value ? formatRut(value) : '';
+  }
+}

--- a/src/app/utils/rut.ts
+++ b/src/app/utils/rut.ts
@@ -20,3 +20,17 @@ export function validarRut(rut: string): boolean {
   else dvCalc = expected.toString();
   return dvCalc === dv;
 }
+
+export function formatRut(rut: string): string {
+  const limpio = cleanRut(rut);
+  if (limpio.length <= 1) return limpio;
+  const cuerpo = limpio.slice(0, -1);
+  const dv = limpio.slice(-1);
+  let formatted = '';
+  for (let i = cuerpo.length; i > 0; i -= 3) {
+    const start = Math.max(i - 3, 0);
+    const segment = cuerpo.slice(start, i);
+    formatted = segment + (formatted ? '.' + formatted : '');
+  }
+  return `${formatted}-${dv}`;
+}


### PR DESCRIPTION
## Summary
- strip hyphen when importing students from CSV
- create `formatRut` util and `RutFormatPipe` for UI display
- show formatted RUT across admin grids and dialogs
- show all students in management grid

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d37c59d0832b96920a5674a75c2e