### PR TITLE
Add RA summary conclusions

### DIFF
--- a/backend/utils/openai.js
+++ b/backend/utils/openai.js
@@ -122,3 +122,14 @@ exports.recomendacionesGenerales = (temas, asignaturaNombre, carreraNombre) => {
   return safe(prompt, `Recomendaciones para ${temas}`);
 };
 
+exports.conclusionRA = ({
+  raNombre,
+  raDescripcion,
+  promedio,
+  asignaturaNombre,
+  carreraNombre,
+}) => {
+  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, redacta una breve conclusión pedagógica sobre el resultado de aprendizaje "${raNombre}" (${raDescripcion}). El puntaje promedio de sus indicadores es ${promedio}.`;
+  return safe(prompt, `Conclusión de ${raNombre}: ${promedio}`);
+};
+


### PR DESCRIPTION
## Summary
- summarize RA data per instancia and ask OpenAI to draft RA conclusions
- include RA conclusions in report generation
- render RA tables and bullet points in generated PDF/DOCX

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2e563338832ba15e72a2f4e26baa