### PR TITLE
Remove RA data from informe summary

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -223,21 +223,10 @@ exports.generarInforme = async asignaturaId => {
         criterios: [],
         analisis: [],
         competencias: {},
-        raMap: {},
       };
     }
     instancias[d.instancia].criterios.push(d);
     instancias[d.instancia].analisis.push(analisis[idx]);
-
-    const ra = instancias[d.instancia].raMap[d.raNombre] || {
-      raNombre: d.raNombre,
-      raDescripcion: d.raDescripcion,
-      sum: 0,
-      count: 0,
-    };
-    ra.sum += Number(d.promedio);
-    ra.count += 1;
-    instancias[d.instancia].raMap[d.raNombre] = ra;
 
     const claves = String(d.competencia || '').split(/\s*\+\s*/).filter(Boolean);
     if (!claves.length) claves.push('Desconocida');
@@ -302,23 +291,6 @@ exports.generarInforme = async asignaturaId => {
       )
     );
 
-    i.raResumen = Object.values(i.raMap || {}).map(r => ({
-      ra: r.raNombre,
-      descripcion: r.raDescripcion,
-      promedio: Math.round((r.sum / r.count) * 10) / 10,
-    }));
-    i.raConclusiones = await Promise.all(
-      i.raResumen.map(r =>
-        conclusionRA({
-          raNombre: r.ra,
-          raDescripcion: r.descripcion,
-          promedio: r.promedio,
-          asignaturaNombre: asignatura.Nombre,
-          carreraNombre: asignatura.Carrera,
-        })
-      )
-    );
-    delete i.raMap;
   }
 
   // totalNiveles ya calculado al agregar rubricas


### PR DESCRIPTION
## Summary
- stop aggregating RA values in `generarInforme`
- avoid sending RA summary/conclusion data to `reportGenerator`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e17dc4f2c832b9775a0c492c864e7