### PR TITLE
Update competency aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ To start the backend API, change into the `backend/` directory and run:
 npm start
 ```
 
+To run the backend unit tests use:
+
+```bash
+npm test
+```
+
 ## Code scaffolding
 
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node utils/__tests__/resumenCompetencias.test.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/utils/__tests__/resumenCompetencias.test.js
+++ b/backend/utils/__tests__/resumenCompetencias.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { calcularResumenCompetencias } = require('../resumenCompetencias');
+
+// Helper to find a row by competencia
+function row(resumen, competencia) {
+  return resumen.find(r => r.competencia === competencia);
+}
+
+// Test splitting of points when multiple competencias are present
+const resumen = calcularResumenCompetencias([
+  { puntaje_maximo: 10, promedio_obtenido: 8, competencias: 'C1 + C2' },
+  { puntaje_maximo: 5, promedio_obtenido: 2, competencias: 'C1' }
+]);
+
+const c1 = row(resumen, 'C1');
+const c2 = row(resumen, 'C2');
+const total = row(resumen, 'Total');
+
+assert.strictEqual(c1.puntajeIdeal, 10);
+assert.strictEqual(c1.promedio, 6);
+assert.strictEqual(c2.puntajeIdeal, 5);
+assert.strictEqual(c2.promedio, 4);
+assert.strictEqual(total.puntajeIdeal, 15);
+assert.strictEqual(total.promedio, 10);
+
+console.log('All tests passed');
+

--- a/backend/utils/resumenCompetencias.js
+++ b/backend/utils/resumenCompetencias.js
@@ -11,13 +11,15 @@ function calcularResumenCompetencias(datos) {
   datos.forEach(d => {
     const comps = parseCompetencias(d.competencias);
     if (!comps.length) comps.push('Desconocida');
+    // Split points evenly across all competencies for this indicator
+    const count = comps.length;
     comps.forEach(c => {
       if (!map[c]) map[c] = { puntajeIdeal: 0, promedio: 0 };
       if (typeof d.puntaje_maximo === 'number') {
-        map[c].puntajeIdeal += d.puntaje_maximo;
+        map[c].puntajeIdeal += d.puntaje_maximo / count;
       }
       if (typeof d.promedio_obtenido === 'number') {
-        map[c].promedio += d.promedio_obtenido;
+        map[c].promedio += d.promedio_obtenido / count;
       }
     });
   });


### PR DESCRIPTION
## Summary
- split indicator scores evenly across competencies in `resumenCompetencias`
- add simple node-based unit test covering the new behavior
- expose test script in backend's `package.json`
- document backend test command in `README`

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_684e35428874832bab98bac13525e662