### PR TITLE
Fix competencia summary calculation

### DIFF
--- a/backend/utils/__tests__/resumenCompetencias.test.js
+++ b/backend/utils/__tests__/resumenCompetencias.test.js
@@ -6,7 +6,7 @@ function row(resumen, competencia) {
   return resumen.find(r => r.competencia === competencia);
 }
 
-// Test splitting of points when multiple competencias are present
+// Test counting full points for each competencia when multiple competencias are present
 const resumen = calcularResumenCompetencias([
   { puntaje_maximo: 10, promedio_obtenido: 8, competencias: 'C1 + C2' },
   { puntaje_maximo: 5, promedio_obtenido: 2, competencias: 'C1' }
@@ -16,12 +16,12 @@ const c1 = row(resumen, 'C1');
 const c2 = row(resumen, 'C2');
 const total = row(resumen, 'Total');
 
-assert.strictEqual(c1.puntajeIdeal, 10);
-assert.strictEqual(c1.promedio, 6);
-assert.strictEqual(c2.puntajeIdeal, 5);
-assert.strictEqual(c2.promedio, 4);
-assert.strictEqual(total.puntajeIdeal, 15);
-assert.strictEqual(total.promedio, 10);
+assert.strictEqual(c1.puntajeIdeal, 15);
+assert.strictEqual(c1.promedio, 10);
+assert.strictEqual(c2.puntajeIdeal, 10);
+assert.strictEqual(c2.promedio, 8);
+assert.strictEqual(total.puntajeIdeal, 25);
+assert.strictEqual(total.promedio, 18);
 
 console.log('All tests passed');
 

--- a/backend/utils/resumenCompetencias.js
+++ b/backend/utils/resumenCompetencias.js
@@ -11,15 +11,14 @@ function calcularResumenCompetencias(datos) {
   datos.forEach(d => {
     const comps = parseCompetencias(d.competencias);
     if (!comps.length) comps.push('Desconocida');
-    // Split points evenly across all competencies for this indicator
-    const count = comps.length;
     comps.forEach(c => {
       if (!map[c]) map[c] = { puntajeIdeal: 0, promedio: 0 };
       if (typeof d.puntaje_maximo === 'number') {
-        map[c].puntajeIdeal += d.puntaje_maximo / count;
+        // Count the full score for each associated competencia
+        map[c].puntajeIdeal += d.puntaje_maximo;
       }
       if (typeof d.promedio_obtenido === 'number') {
-        map[c].promedio += d.promedio_obtenido / count;
+        map[c].promedio += d.promedio_obtenido;
       }
     });
   });


### PR DESCRIPTION
## Summary
- update calculation of competency summary to count full points when an indicator belongs to multiple competencies
- adjust unit test accordingly

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e6cde4134832badea55d68bd82e2f