### PR TITLE
Orientación horizontal de gráfico de indicadores

### DIFF
--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -73,15 +73,15 @@ async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png'
       datasets,
     },
     options: {
-      indexAxis: 'x',
+      indexAxis: 'y',
       scales: {
-        y: {
+        x: {
           beginAtZero: true,
           max: 100,
           ticks: { stepSize: 10 },
           title: { display: true, text: '% de Alumnos' },
         },
-        x: {
+        y: {
           title: { display: true, text: 'Indicadores' },
         },
       },

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -587,7 +587,7 @@ function generarBloqueDesgloseIndicadoresDOCX(instancia) {
 function buildBarChart(labels, values) {
   if (!Chart) return null;
   return new Chart({
-    type: ChartType.COLUMN,
+    type: ChartType.BAR,
     width: 500,
     height: 250,
     legend: { position: 'none' },


### PR DESCRIPTION
## Summary
- orient graph bars so indicators are on the Y axis in generated PNG and DOCX

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684f592f06f8832badeaf71fd48d717b