### PR TITLE
Gráficos individuales por indicador

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -356,10 +356,14 @@ exports.generarInforme = async asignaturaId => {
 
   const graficosInstancias = {};
   for (const [num, inst] of Object.entries(instancias)) {
-    graficosInstancias[num] = await generarGraficoBarras(
-      inst.criterios.map(c => c.indicador),
-      inst.criterios.map(c => Number(c.porcentaje) || 0),
-      `instancia_${num}.png`
+    graficosInstancias[num] = await Promise.all(
+      inst.criterios.map((c, idx) =>
+        generarGraficoBarras(
+          [c.indicador],
+          [Number(c.porcentaje) || 0],
+          `instancia_${num}_${idx}.png`
+        )
+      )
     );
   }
 
@@ -401,7 +405,10 @@ exports.generarInforme = async asignaturaId => {
   if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
 
   if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
-  const archivosGraficos = [barrasPath, compPath, ...Object.values(graficosInstancias)];
+  const archivosGraficos = [barrasPath, compPath];
+  Object.values(graficosInstancias).forEach(arr => {
+    archivosGraficos.push(...arr);
+  });
   archivosGraficos.forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -50,19 +50,29 @@ async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png'
       label: 'Alumnos sobre promedio (%)',
       data: datos.map(d => Number(d) || 0),
       backgroundColor: defaultColors[3],
+      maxBarThickness: 40,
+      barPercentage: 0.5,
     });
   } else if (Array.isArray(datos)) {
     datasets = datos.map((ds, idx) => {
       const label = ds.label || `Serie ${idx + 1}`;
       const data = (ds.data || []).map(d => Number(d) || 0);
       const bg = ds.backgroundColor || ds.color || colorMap[label] || defaultColors[idx % defaultColors.length];
-      return { label, data, backgroundColor: bg };
+      return {
+        label,
+        data,
+        backgroundColor: bg,
+        maxBarThickness: 40,
+        barPercentage: 0.5,
+      };
     });
   } else if (typeof datos === 'object' && datos !== null) {
     datasets = Object.entries(datos).map(([label, data], idx) => ({
       label,
       data: (data || []).map(d => Number(d) || 0),
       backgroundColor: colorMap[label] || defaultColors[idx % defaultColors.length],
+      maxBarThickness: 40,
+      barPercentage: 0.5,
     }));
   }
 
@@ -73,15 +83,15 @@ async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png'
       datasets,
     },
     options: {
-      indexAxis: 'x',
+      indexAxis: 'y',
       scales: {
-        y: {
+        x: {
           beginAtZero: true,
           max: 100,
           ticks: { stepSize: 10 },
           title: { display: true, text: '% de Alumnos' },
         },
-        x: {
+        y: {
           title: { display: true, text: 'Indicadores' },
         },
       },

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -196,11 +196,14 @@ function generarBloqueDesgloseIndicadoresPDF(doc, instancia) {
   });
 }
 
-function generarGraficoDesempenoPDF(doc, path) {
-  if (path && fs.existsSync(path)) {
-    doc.image(path, { width: 500 });
-    doc.moveDown();
-  }
+function generarGraficoDesempenoPDF(doc, paths) {
+  const arr = Array.isArray(paths) ? paths : [paths];
+  arr.forEach(p => {
+    if (p && fs.existsSync(p)) {
+      doc.image(p, { width: 500 });
+      doc.moveDown();
+    }
+  });
 }
 
 function generarTablaCriteriosPorIndicadorPDF(doc, instancia) {
@@ -587,7 +590,7 @@ function generarBloqueDesgloseIndicadoresDOCX(instancia) {
 function buildBarChart(labels, values) {
   if (!Chart) return null;
   return new Chart({
-    type: ChartType.COLUMN,
+    type: ChartType.BAR,
     width: 500,
     height: 250,
     legend: { position: 'none' },
@@ -1017,12 +1020,15 @@ exports.generarDOCXCompleto = async contenido => {
       // B. Desglose por indicador
       instanciasParagraphs.push(...generarBloqueDesgloseIndicadoresDOCX(inst));
       // C. Gráfico por instancia
-      const graf = generarGraficoDesempenoDOCX(
-        inst.criterios.map(c => c.indicador),
-        inst.criterios.map(c => c.porcentaje),
-        contenido.graficos && contenido.graficos[num]
-      );
-      if (graf) instanciasParagraphs.push(graf);
+      const grafPaths = (contenido.graficos && contenido.graficos[num]) || [];
+      inst.criterios.forEach((c, idx) => {
+        const graf = generarGraficoDesempenoDOCX(
+          [c.indicador],
+          [c.porcentaje],
+          grafPaths[idx]
+        );
+        if (graf) instanciasParagraphs.push(graf);
+      });
       // D. Tabla de distribución de niveles por criterio
       instanciasParagraphs.push(generarTablaCriteriosPorIndicadorDOCX(inst));
       const grafNivel = generarGraficoDistribucionNivelesDOCX(inst);


### PR DESCRIPTION
## Summary
- generar un gráfico por indicador en cada instancia evaluativa
- insertar todas las imágenes correspondientes en el PDF y DOCX
- limitar el grosor de cada barra

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_684f592f06f8832badeaf71fd48d717b