### PR TITLE
Add pie chart percentages and reposition graphs

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -4,6 +4,7 @@ const path = require('path');
 const {
   generarGraficoBarras,
   generarGraficoLineas,
+  generarGraficoTorta,
 } = require('../utils/grafico');
 const {
   crearIntroduccion,
@@ -356,15 +357,25 @@ exports.generarInforme = async asignaturaId => {
 
   const graficosInstancias = {};
   for (const [num, inst] of Object.entries(instancias)) {
-    graficosInstancias[num] = await Promise.all(
-      inst.criterios.map((c, idx) =>
-        generarGraficoBarras(
-          [c.indicador],
-          [Number(c.porcentaje) || 0],
-          `instancia_${num}_${idx}.png`
-        )
-      )
-    );
+    const barras = [];
+    const tortas = [];
+    for (const [idx, c] of inst.criterios.entries()) {
+      const barra = await generarGraficoBarras(
+        [c.indicador],
+        [Number(c.porcentaje) || 0],
+        `instancia_${num}_${idx}.png`
+      );
+      barras.push(barra);
+      const labels = (c.niveles || []).map(n => n.nombre);
+      const valores = (c.niveles || []).map(n => n.porcentaje);
+      const torta = await generarGraficoTorta(
+        labels,
+        valores,
+        `instancia_${num}_${idx}_pie.png`
+      );
+      tortas.push(torta);
+    }
+    graficosInstancias[num] = { barras, tortas };
   }
 
   const resumenIndicadores = [...datos].sort((a, b) => a.instancia - b.instancia);
@@ -406,8 +417,9 @@ exports.generarInforme = async asignaturaId => {
 
   if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   const archivosGraficos = [barrasPath, compPath];
-  Object.values(graficosInstancias).forEach(arr => {
-    archivosGraficos.push(...arr);
+  Object.values(graficosInstancias).forEach(obj => {
+    if (obj.barras) archivosGraficos.push(...obj.barras);
+    if (obj.tortas) archivosGraficos.push(...obj.tortas);
   });
   archivosGraficos.forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -126,13 +126,27 @@ async function generarGraficoTorta(labels, datos, nombreArchivo = 'torta.png') {
       datasets: [
         {
           data: datos,
-          backgroundColor: [
-            'rgba(75, 192, 192, 0.6)',
-            'rgba(255, 205, 86, 0.6)',
-            'rgba(255, 99, 132, 0.6)'
-          ],
+          backgroundColor: labels.map((_, i) => {
+            const colors = [
+              'rgba(75, 192, 192, 0.6)',
+              'rgba(54, 162, 235, 0.6)',
+              'rgba(255, 205, 86, 0.6)',
+              'rgba(255, 99, 132, 0.6)',
+              'rgba(153, 102, 255, 0.6)',
+              'rgba(201, 203, 207, 0.6)',
+            ];
+            return colors[i % colors.length];
+          }),
         },
       ],
+    },
+    options: {
+      plugins: {
+        datalabels: {
+          color: '#000000',
+          formatter: v => `${v}%`,
+        },
+      },
     },
   };
   const buffer = await chartJSNodeCanvas.renderToBuffer(config);


### PR DESCRIPTION
## Summary
- separate bar and pie chart paths when generating instance graphics
- insert pie charts after the distribution table in reports
- render percentages inside pie charts using datalabels

## Testing
- `npm test --silent` *(fails: ng not found)*
- `cd backend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f6464e04c832ba86c93db902843d3