### PR TITLE
Update pie chart labels and remove global bar chart

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -343,12 +343,6 @@ exports.generarInforme = async asignaturaId => {
     asignatura.Carrera
   );
 
-  const barrasPath = await generarGraficoBarras(
-    datos.map(d => d.indicador),
-    datos.map(d => Number(d.porcentaje) || 0),
-    'barras.png'
-  );
-
   const compPath = await generarGraficoLineas(
     competencias.map(c => c.ID_Competencia),
     competencias.map(c => Number(c.cumplimiento) || 0),
@@ -392,7 +386,7 @@ exports.generarInforme = async asignaturaId => {
     conclusion,
     recomendaciones,
     recomendacionesTemasFinal,
-    graficos: { barrasPath, compPath, ...graficosInstancias },
+    graficos: { compPath, ...graficosInstancias },
   };
 
   let pdf = Buffer.from('');
@@ -416,7 +410,7 @@ exports.generarInforme = async asignaturaId => {
   if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
 
   if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
-  const archivosGraficos = [barrasPath, compPath];
+  const archivosGraficos = [compPath];
   Object.values(graficosInstancias).forEach(obj => {
     if (obj.barras) archivosGraficos.push(...obj.barras);
     if (obj.tortas) archivosGraficos.push(...obj.tortas);

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -144,7 +144,12 @@ async function generarGraficoTorta(labels, datos, nombreArchivo = 'torta.png') {
       plugins: {
         datalabels: {
           color: '#000000',
-          formatter: v => `${v}%`,
+          formatter: (val, ctx) => {
+            const data = ctx.chart.data.datasets[0].data || [];
+            const sum = data.reduce((acc, d) => acc + Number(d || 0), 0);
+            const pct = sum ? (val / sum) * 100 : 0;
+            return `${pct % 1 ? pct.toFixed(1) : pct}%`;
+          },
         },
       },
     },

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -1057,14 +1057,6 @@ exports.generarDOCXCompleto = async contenido => {
     });
 
   const grafParags = [];
-  if (Array.isArray(contenido.datos) && contenido.datos.length) {
-    const g = generarGraficoDesempenoDOCX(
-      contenido.datos.map(d => d.indicador),
-      contenido.datos.map(d => d.porcentaje),
-      contenido.graficos && contenido.graficos.barrasPath
-    );
-    if (g) grafParags.push(g);
-  }
   if (Array.isArray(contenido.competencias) && contenido.competencias.length) {
     const g = generarGraficoDesempenoDOCX(
       contenido.competencias.map(c => c.ID_Competencia),


### PR DESCRIPTION
## Summary
- show the percentage for each slice in pie charts
- drop generation of the global indicators bar graph
- adjust report generator to only include competency chart

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6a8ba130832ba6535a4cf55e1d41