### PR TITLE
Add user search filters

### DIFF
--- a/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.html
+++ b/src/app/modules/admin/usuarios/main-usuarios/main-usuarios.component.html
@@ -13,6 +13,25 @@
       </h3>
     </div>
 
+    <div class="card mb-4">
+      <div class="card-body">
+        <div class="row g-2">
+          <div class="col-md-4">
+            <input type="text" class="form-control" placeholder="Buscar por RUT..." [(ngModel)]="filtroId" (input)="aplicarFiltros()" />
+          </div>
+          <div class="col-md-4">
+            <input type="text" class="form-control" placeholder="Nombre o apellido..." [(ngModel)]="filtroTexto" (input)="aplicarFiltros()" />
+          </div>
+          <div class="col-md-4">
+            <select class="form-select" [(ngModel)]="filtroRol" (change)="aplicarFiltros()">
+              <option value="">Todos los roles</option>
+              <option *ngFor="let r of roles" [value]="r">{{ r }}</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div *ngFor="let grupo of agrupados" class="mb-4">
       <div class="card shadow-sm border-0">
         <div class="card-header fw-bold" style="background-color: #0073E6; color: white;">


### PR DESCRIPTION
## Summary
- add search controls for admin user management
- support filtering users by ID, name and role

## Testing
- `npm test` *(fails: ng not found)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850aa969b6c832bb0502807861117d2