### PR TITLE
Add search to admin subject list

### DIFF
--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.html
@@ -20,6 +20,18 @@
       </h3>
     </div>
 
+    <div class="card mb-4">
+      <div class="card-body">
+        <input
+          type="text"
+          class="form-control"
+          placeholder="Buscar por ID o nombre..."
+          [(ngModel)]="filtroTexto"
+          (input)="aplicarFiltro()"
+        />
+      </div>
+    </div>
+
     <div *ngFor="let grupo of asignaturasPorCarrera" class="mb-4">
       <div class="card shadow-sm border-0">
         <div class="card-header fw-bold" style="background-color: #0073E6; color: white;">

--- a/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
+++ b/src/app/modules/admin/asignaturas/main-asignaturas/main-asignaturas.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { DialogAsignaturaComponent } from '../dialog-asignatura/dialog-asignatura.component';
@@ -12,13 +13,15 @@ import { SidebarComponent } from '../../../../shared/components/sidebar/sidebar.
 @Component({
   selector: 'app-main-asignaturas',
   standalone: true,
-  imports: [CommonModule, NgbModalModule, SidebarComponent],
+  imports: [CommonModule, FormsModule, NgbModalModule, SidebarComponent],
   templateUrl: './main-asignaturas.component.html',
   styleUrls: ['./main-asignaturas.component.css']
 })
 export class MainAsignaturasComponent implements OnInit {
   rolUsuario: string = '';
   asignaturasPorCarrera: { carrera: string; asignaturas: Asignatura[] }[] = [];
+  asignaturas: Asignatura[] = [];
+  filtroTexto: string = '';
 
   constructor(
     private modalService: NgbModal,
@@ -32,17 +35,27 @@ export class MainAsignaturasComponent implements OnInit {
 
   cargarAsignaturas() {
     this.asignaturaService.obtenerTodas().subscribe(data => {
-      const agrupadas: { [key: string]: Asignatura[] } = {};
-      for (const a of data) {
-        const key = a.Carrera || '';
-        if (!agrupadas[key]) agrupadas[key] = [];
-        agrupadas[key].push(a);
-      }
-      this.asignaturasPorCarrera = Object.keys(agrupadas).map(k => ({
-        carrera: k,
-        asignaturas: agrupadas[k]
-      }));
+      this.asignaturas = data;
+      this.aplicarFiltro();
     });
+  }
+
+  aplicarFiltro() {
+    const texto = this.filtroTexto.toLowerCase();
+    const filtradas = this.asignaturas.filter(a =>
+      a.ID_Asignatura.toLowerCase().includes(texto) ||
+      a.Nombre.toLowerCase().includes(texto)
+    );
+    const agrupadas: { [key: string]: Asignatura[] } = {};
+    for (const a of filtradas) {
+      const key = a.Carrera || '';
+      if (!agrupadas[key]) agrupadas[key] = [];
+      agrupadas[key].push(a);
+    }
+    this.asignaturasPorCarrera = Object.keys(agrupadas).map(k => ({
+      carrera: k,
+      asignaturas: agrupadas[k]
+    }));
   }
 
   abrirDialog(modo: 'crear' | 'ver' | 'editar', asignatura?: Asignatura) {


### PR DESCRIPTION
## Summary
- add search input for subjects grouped by career
- filter subjects by ID or name in `MainAsignaturasComponent`

## Testing
- `npm test` *(fails: ng not found)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ac55bd90832b9cbfc8180c4f07e3