### PR TITLE
Limit report generation to Word and refine prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Install dependencies and start the API server:
 ```bash
 cd backend
 npm install
-# If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
-# npm install pdfkit docx chartjs-node-canvas@latest
+# If docx or chartjs-node-canvas are missing, install them explicitly
+# npm install docx chartjs-node-canvas@latest
 # If you hit "No matching version" errors for chartjs-node-canvas, try:
 # npm install chartjs-node-canvas@latest
 # On Linux you may also need development headers for the `canvas` package:
@@ -97,37 +97,31 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 
 ## Automatic subject reports
 
-The backend exposes `/api/informe/:asignaturaId` to generate a full PDF
-and Word report for a given course. Make sure you install backend
+The backend exposes `/api/informe/:asignaturaId/word` to generate a Word report for a given course. Make sure you install backend
 dependencies before running the server:
 
 ```bash
 cd backend
 npm install
-# If pdfkit, docx or chartjs-node-canvas are missing, install them explicitly
-# npm install pdfkit docx chartjs-node-canvas@latest
+# If docx or chartjs-node-canvas are missing, install them explicitly
+# npm install docx chartjs-node-canvas@latest
 # On Linux you may also need development headers for the `canvas` package:
 # sudo apt-get install -y build-essential libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
 ```
 
-These dependencies include `pdfkit`, `docx` and `chartjs-node-canvas`, which are required to generate reports with charts.
+These dependencies include `docx` and `chartjs-node-canvas`, which are required to generate reports with charts.
 
-Reports are saved under `backend/uploads/` and the API returns a ZIP file
-containing both the PDF and Word versions.
+Reports are saved under `backend/uploads/` and the API returns the generated Word document.
 
-If `pdfkit` is not installed, the generated ZIP will only include the Word
-document because the PDF cannot be created. Make sure all optional
-dependencies are installed if you need the PDF output.
 
 ### Troubleshooting
 
-If you see an error like `Cannot find module 'pdfkit'` when starting the
 backend, install the missing dependencies inside `backend/`:
 
 ```bash
 cd backend
 
-npm install pdfkit docx chartjs-node-canvas@latest
+npm install docx chartjs-node-canvas@latest
 ```
 
 If `npm install` fails with a message like `No matching version found for chartjs-node-canvas@^4.2.2`,
@@ -140,7 +134,7 @@ npm install chartjs-node-canvas@latest
 ```
 
 Without these packages the report generator will skip chart creation. If your
-generated PDF or Word files are missing graphs, verify that `pdfkit`, `docx`
+generated Word files are missing graphs, verify that `docx`
 and `chartjs-node-canvas` are installed correctly.
 
 ## Additional Resources

--- a/backend/controllers/informe.controller.js
+++ b/backend/controllers/informe.controller.js
@@ -1,42 +1,5 @@
 const InformeService = require('../services/informe.service');
 
-exports.generar = async (req, res) => {
-  const { asignaturaId } = req.params;
-  try {
-  const { pdf, docx, nombre, nombreDocx } = await InformeService.generarInforme(asignaturaId);
-  const zip = require('jszip')();
-  if (pdf && pdf.length) {
-    zip.file(nombre, pdf);
-  } else {
-    console.warn('PDF not included in ZIP: generation failed or dependency missing');
-  }
-  if (docx && docx.length) {
-    zip.file(nombreDocx, docx);
-  } else {
-    console.warn('DOCX not included in ZIP: generation failed or dependency missing');
-  }
-    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
-    res.setHeader('Content-Type', 'application/zip');
-    res.setHeader('Content-Disposition', `attachment; filename=Informe-${asignaturaId}.zip`);
-    return res.send(buffer);
-  } catch (err) {
-    console.error('Error al generar informe', err);
-    res.status(500).json({ message: 'Error al generar informe' });
-  }
-};
-
-exports.pdf = async (req, res) => {
-  const { asignaturaId } = req.params;
-  try {
-    const { pdf, nombre } = await InformeService.generarInforme(asignaturaId);
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename=${nombre}`);
-    return res.send(pdf);
-  } catch (err) {
-    console.error('Error al generar PDF', err);
-    res.status(500).json({ message: 'Error al generar informe' });
-  }
-};
 
 exports.word = async (req, res) => {
   const { asignaturaId } = req.params;

--- a/backend/routes/informe.routes.js
+++ b/backend/routes/informe.routes.js
@@ -3,8 +3,6 @@ const router = Router();
 const InformeController = require('../controllers/informe.controller');
 
 router.get('/jefe/:idUsuario', InformeController.asignaturasDelJefe);
-router.get('/:asignaturaId', InformeController.generar);
-router.get('/:asignaturaId/pdf', InformeController.pdf);
 router.get('/:asignaturaId/word', InformeController.word);
 
 module.exports = router;

--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -17,7 +17,7 @@ const {
   analisisCompetencia,
   recomendacionesGenerales,
 } = require('../utils/openai');
-const { generarPDFCompleto, generarDOCXCompleto } = require('../utils/reportGenerator');
+const { generarDOCXCompleto } = require('../utils/reportGenerator');
 const {
   calcularResumenCompetencias,
 } = require('../utils/resumenCompetencias');
@@ -389,13 +389,6 @@ exports.generarInforme = async asignaturaId => {
     graficos: { compPath, ...graficosInstancias },
   };
 
-  let pdf = Buffer.from('');
-  try {
-    pdf = await generarPDFCompleto(contenido);
-  } catch (err) {
-    console.warn('PDF generation skipped:', err.message);
-  }
-
   let docx = Buffer.from('');
   try {
     docx = await generarDOCXCompleto(contenido);
@@ -407,8 +400,6 @@ exports.generarInforme = async asignaturaId => {
   const base = `Informe-${asignatura.Nombre}-${new Date().toISOString().split('T')[0]}`.replace(/\s+/g, '_');
   const outDir = path.join(__dirname, '..', 'uploads');
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
-  if (pdf.length) fs.writeFileSync(path.join(outDir, `${base}.pdf`), pdf);
-
   if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   const archivosGraficos = [compPath];
   Object.values(graficosInstancias).forEach(obj => {
@@ -418,5 +409,5 @@ exports.generarInforme = async asignaturaId => {
   archivosGraficos.forEach(p => {
     if (fs.existsSync(p)) fs.unlinkSync(p);
   });
-  return { pdf, docx, nombre: `${base}.pdf`, nombreDocx: `${base}.docx` };
+  return { docx, nombreDocx: `${base}.docx` };
 };

--- a/backend/utils/openai.js
+++ b/backend/utils/openai.js
@@ -88,22 +88,22 @@ exports.analizarCriterio = ({
   asignaturaNombre,
   carreraNombre,
 }) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, correspondiente al contenido "${contenidoNucleo}" (${contenidoDescripcion}) y al resultado de aprendizaje "${raNombre}" (${raDescripcion}), redacta un análisis pedagógico y recomendaciones para el criterio "${indicador}" evaluado en "${evaluacion}". Resultados obtenidos: Máximo ${max}, Mínimo ${min}, Promedio ${promedio}, ${porcentaje}% sobre el promedio.`;
+  const prompt = `Teniendo en cuenta los datos de las tablas de Evaluación, Indicador, Resultado de Aprendizaje, Contenido y Aplicación, analiza pedagógicamente el criterio "${indicador}" evaluado en "${evaluacion}" dentro de la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}. El contenido relacionado es "${contenidoNucleo}" (${contenidoDescripcion}) y corresponde al RA "${raNombre}" (${raDescripcion}). Se obtuvo un puntaje máximo de ${max}, un mínimo de ${min}, un promedio de ${promedio} y un logro del ${porcentaje}%. Incluye recomendaciones de mejora.`;
   return safe(prompt, `Análisis de ${indicador}`);
 };
 
 exports.conclusionCompetencias = ({ resumen, asignaturaNombre, carreraNombre }) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, redacta una conclusión general del rendimiento de los estudiantes considerando los siguientes resultados por competencia: ${resumen}.`;
+  const prompt = `A partir de toda la información registrada en las evaluaciones y resúmenes de competencias, elabora una conclusión global sobre el rendimiento de los estudiantes en la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}. Utiliza los porcentajes de cumplimiento por competencia: ${resumen}.`;
   return safe(prompt, `Conclusión de competencias: ${resumen}`);
 };
 
 exports.recomendacionesTemas = (temas, asignaturaNombre, carreraNombre) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, entrega recomendaciones generales de mejora para los siguientes temas: ${temas}.`;
+  const prompt = `Considerando el desempeño observado en las evaluaciones y las necesidades detectadas, sugiere recomendaciones para mejorar los siguientes temas en la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}: ${temas}.`;
   return safe(prompt, `Recomendaciones para ${temas}`);
 };
 
 exports.conclusionCriterios = ({ resumen, asignaturaNombre, carreraNombre }) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, redacta una conclusión breve sobre el rendimiento observado en los siguientes criterios: ${resumen}.`;
+  const prompt = `Utilizando la información disponible en las tablas de Indicadores y Aplicación, redacta una síntesis del rendimiento alcanzado en los criterios: ${resumen}. Esta conclusión corresponde a la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}.`;
   return safe(prompt, `Conclusion de criterios: ${resumen}`);
 };
 
@@ -113,17 +113,17 @@ exports.recomendacionesCompetencia = (
   asignaturaNombre,
   carreraNombre,
 ) => {
-  const prompt = `Actúa como un experto pedagogo. En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, la competencia ${competencia} registra un cumplimiento de ${cumplimiento}%. Sugiere acciones concretas, estrategias de enseñanza y actividades que ayuden a mejorar esta competencia.`;
+  const prompt = `Actúa como un experto pedagogo y, considerando toda la evidencia obtenida en las evaluaciones, propone acciones concretas y estrategias de enseñanza que permitan mejorar la competencia ${competencia} que actualmente presenta un ${cumplimiento}% de cumplimiento en la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}.`;
   return safe(prompt, `Recomendaciones para ${competencia}`);
 };
 
 exports.analisisCompetencia = ({ competencia, puntajeIdeal, promedio, cumplimiento, asignaturaNombre, carreraNombre }) => {
-  const prompt = `Eres un experto en educación superior. En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre} se obtuvo un puntaje ideal de ${puntajeIdeal} para la competencia ${competencia}. El promedio alcanzado fue de ${promedio} y el cumplimiento fue ${cumplimiento}%. Redacta un análisis pedagógico detallado considerando causas posibles y su impacto en la formación profesional.`;
+  const prompt = `Con base en las cifras registradas en las distintas evaluaciones, analiza en detalle la competencia ${competencia} de la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}. El puntaje ideal fue ${puntajeIdeal}, el promedio ${promedio} y el grado de cumplimiento ${cumplimiento}%. Explica posibles causas de estos resultados y cómo repercuten en la formación profesional.`;
   return safe(prompt, `Analisis de la competencia ${competencia}`);
 };
 
 exports.recomendacionesGenerales = (temas, asignaturaNombre, carreraNombre) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, entrega recomendaciones generales para reforzar los siguientes temas: ${temas}.`;
+  const prompt = `Revisa los resultados obtenidos en las distintas evaluaciones y formula recomendaciones generales para reforzar los temas ${temas} en la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}.`;
   return safe(prompt, `Recomendaciones para ${temas}`);
 };
 
@@ -134,7 +134,7 @@ exports.conclusionRA = ({
   asignaturaNombre,
   carreraNombre,
 }) => {
-  const prompt = `En la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}, redacta una breve conclusión pedagógica sobre el resultado de aprendizaje "${raNombre}" (${raDescripcion}). El puntaje promedio de sus indicadores es ${promedio}.`;
+  const prompt = `Tomando en cuenta la información de las tablas relacionadas con el resultado de aprendizaje, redacta una conclusión breve sobre "${raNombre}" (${raDescripcion}) en la asignatura ${asignaturaNombre} de la carrera ${carreraNombre}. El promedio de sus indicadores es ${promedio}.`;
   return safe(prompt, `Conclusión de ${raNombre}: ${promedio}`);
 };
 

--- a/src/app/modules/jefe-carrera/reportes/reportes.component.html
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.html
@@ -29,11 +29,6 @@
                       <i class="bi bi-file-earmark-word me-1"></i> Word
                     </a>
                   </li>
-                  <li>
-                    <a class="dropdown-item" (click)="descargarPdf(a.ID_Asignatura)">
-                      <i class="bi bi-file-earmark-pdf me-1"></i> PDF
-                    </a>
-                  </li>
                 </ul>
               </div>
             </div>

--- a/src/app/modules/jefe-carrera/reportes/reportes.component.ts
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.ts
@@ -21,27 +21,7 @@ export class ReportesComponent implements OnInit {
     this.asignaturaService.obtenerPorCarreraDelJefe(this.rut).subscribe(a => this.asignaturas = a);
   }
 
-  generar(id: number) {
-    this.reporteService.generar(id).subscribe(blob => {
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `Informe-${id}.pdf`;
-      a.click();
-      window.URL.revokeObjectURL(url);
-    });
-  }
 
-  descargarPdf(id: number) {
-    this.reporteService.pdf(id).subscribe(blob => {
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `Informe-${id}.pdf`;
-      a.click();
-      window.URL.revokeObjectURL(url);
-    });
-  }
 
   descargarWord(id: number) {
     this.reporteService.word(id).subscribe(response => {

--- a/src/app/services/reporte.service.ts
+++ b/src/app/services/reporte.service.ts
@@ -7,14 +7,6 @@ export class ReporteService {
   private apiUrl = `${environment.apiUrl}/api/informe`;
   constructor(private http: HttpClient) {}
 
-  generar(asignaturaId: number) {
-    return this.http.get(`${this.apiUrl}/${asignaturaId}`, { responseType: 'blob' });
-  }
-
-  pdf(asignaturaId: number) {
-    return this.http.get(`${this.apiUrl}/${asignaturaId}/pdf`, { responseType: 'blob' });
-  }
-
   word(asignaturaId: number) {
     return this.http.get(`${this.apiUrl}/${asignaturaId}/word`, {
       responseType: 'blob',


### PR DESCRIPTION
## Summary
- drop PDF generation endpoints and client options
- streamline report generation service to return only Word files
- update prompts for better conclusions using all available data tables
- document the new Word-only workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ffa85f30832b81f87436ea0684c8