### PR TITLE
Add field length validation

### DIFF
--- a/backend/controllers/asignatura.controller.js
+++ b/backend/controllers/asignatura.controller.js
@@ -1,4 +1,5 @@
 const AsignaturaService = require('../services/asignatura.service');
+const { validateLengths } = require('../utils/validateLengths');
 
 exports.obtenerTodas = async (req, res) => {
   const data = await AsignaturaService.obtenerTodas();
@@ -28,6 +29,13 @@ exports.obtenerPorProfesor = async (req, res) => {
 };
 
 exports.crear = async (req, res) => {
+  const { ID_Asignatura, Nombre, usuario_ID_Usuario } = req.body;
+  const err = validateLengths(
+    { ID_Asignatura, Nombre, usuario_ID_Usuario },
+    { ID_Asignatura: 10, Nombre: 100, usuario_ID_Usuario: 10 }
+  );
+  if (err) return res.status(400).json({ message: err });
+
   try {
     await AsignaturaService.crear(req.body);
     res.status(201).json({ message: 'Asignatura creada' });
@@ -39,6 +47,13 @@ exports.crear = async (req, res) => {
 
 exports.actualizar = async (req, res) => {
   const id = req.params.id;
+  const { ID_Asignatura, Nombre, usuario_ID_Usuario } = req.body;
+  const err = validateLengths(
+    { ID_Asignatura, Nombre, usuario_ID_Usuario },
+    { ID_Asignatura: 10, Nombre: 100, usuario_ID_Usuario: 10 }
+  );
+  if (err) return res.status(400).json({ message: err });
+
   try {
     await AsignaturaService.actualizar(id, req.body);
     res.json({ message: 'Asignatura actualizada' });

--- a/backend/controllers/carrera.controller.js
+++ b/backend/controllers/carrera.controller.js
@@ -1,4 +1,5 @@
 const CarreraService = require('../services/carrera.service');
+const { validateLengths } = require('../utils/validateLengths');
 
 exports.getAllCarreras = async (req, res) => {
   const carreras = await CarreraService.getAll();
@@ -7,12 +8,24 @@ exports.getAllCarreras = async (req, res) => {
 
 exports.crearCarrera = async (req, res) => {
   const { Nombre, usuario_ID_Usuario } = req.body;
+  const err = validateLengths({ Nombre, usuario_ID_Usuario }, {
+    Nombre: 100,
+    usuario_ID_Usuario: 10
+  });
+  if (err) return res.status(400).json({ message: err });
+
   await CarreraService.crear({ Nombre, facultad_ID_Facultad: 1, usuario_ID_Usuario });
   res.status(201).json({ message: 'Carrera creada con éxito' });
 };
 
 exports.actualizarCarrera = async (req, res) => {
   const { Nombre, usuario_ID_Usuario } = req.body;
+  const err = validateLengths({ Nombre, usuario_ID_Usuario }, {
+    Nombre: 100,
+    usuario_ID_Usuario: 10
+  });
+  if (err) return res.status(400).json({ message: err });
+
   await CarreraService.actualizar(req.params.id, { Nombre, usuario_ID_Usuario });
   res.json({ message: 'Carrera actualizada' });
 };

--- a/backend/controllers/usuario.controller.js
+++ b/backend/controllers/usuario.controller.js
@@ -1,4 +1,5 @@
 const UsuarioService = require('../services/usuario.service');
+const { validateLengths } = require('../utils/validateLengths');
 
 // Crear nuevo usuario
 exports.crearUsuario = async (req, res) => {
@@ -8,6 +9,13 @@ exports.crearUsuario = async (req, res) => {
   if (!ID_Usuario || !Nombre || !Clave || !Rol_ID_Rol) {
     return res.status(400).json({ message: 'Faltan datos requeridos para crear el usuario' });
   }
+
+  const err = validateLengths({ ID_Usuario: rut, Nombre, Clave }, {
+    ID_Usuario: 10,
+    Nombre: 100,
+    Clave: 100
+  });
+  if (err) return res.status(400).json({ message: err });
 
   try {
     await UsuarioService.crearUsuario(rut, Nombre, Clave, Rol_ID_Rol);
@@ -78,6 +86,9 @@ exports.actualizarClave = async (req, res) => {
   if (!clave) {
     return res.status(400).json({ message: 'La clave es requerida' });
   }
+
+  const err = validateLengths({ clave }, { clave: 100 });
+  if (err) return res.status(400).json({ message: err });
 
   try {
     await UsuarioService.actualizarClave(id, clave);

--- a/backend/utils/validateLengths.js
+++ b/backend/utils/validateLengths.js
@@ -1,0 +1,11 @@
+function validateLengths(values, limits) {
+  for (const [key, max] of Object.entries(limits)) {
+    const val = values[key];
+    if (typeof val === 'string' && val.length > max) {
+      return `${key} excede el máximo de ${max} caracteres`;
+    }
+  }
+  return null;
+}
+
+module.exports = { validateLengths };


### PR DESCRIPTION
## Summary
- add reusable `validateLengths` utility
- enforce character limits when creating or updating usuarios, carreras and asignaturas

## Testing
- `npm test` in `backend`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526a160214832b868601675e0fdae4