### PR TITLE
Add toast when no evaluations for report

### DIFF
--- a/src/app/modules/jefe-carrera/reportes/reportes.component.html
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.html
@@ -38,3 +38,14 @@
     </div>
   </div>
 </div>
+
+<!-- Toast mensaje de error -->
+<div *ngIf="mensajeError" class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 2000">
+  <div class="toast show text-bg-danger bg-opacity-75" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">
+        <i class="bi bi-exclamation-octagon-fill me-2"></i>{{ mensajeError }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/jefe-carrera/reportes/reportes.component.ts
+++ b/src/app/modules/jefe-carrera/reportes/reportes.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { AsignaturaService } from '../../../services/asignatura.service';
 import { ReporteService } from '../../../services/reporte.service';
+import { EvaluacionService } from '../../../services/evaluacion.service';
 import { SidebarComponent } from '../../../shared/components/sidebar/sidebar.component';
 import { CommonModule } from '@angular/common';
 
@@ -14,8 +15,13 @@ import { CommonModule } from '@angular/common';
 export class ReportesComponent implements OnInit {
   asignaturas: any[] = [];
   rut = localStorage.getItem('rut') || '';
+  mensajeError = '';
 
-  constructor(private asignaturaService: AsignaturaService, private reporteService: ReporteService) {}
+  constructor(
+    private asignaturaService: AsignaturaService,
+    private reporteService: ReporteService,
+    private evaluacionService: EvaluacionService
+  ) {}
 
   ngOnInit() {
     this.asignaturaService.obtenerPorCarreraDelJefe(this.rut).subscribe(a => this.asignaturas = a);
@@ -24,16 +30,23 @@ export class ReportesComponent implements OnInit {
 
 
   descargarWord(id: number) {
-    this.reporteService.word(id).subscribe(response => {
-      const blob = response.body as Blob;
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const disposition = response.headers.get('Content-Disposition');
-      const match = disposition?.match(/filename=([^;]+)/);
-      a.download = match ? match[1] : `Informe-${id}.docx`;
-      a.click();
-      window.URL.revokeObjectURL(url);
+    this.evaluacionService.contarPorAsignatura(String(id)).subscribe(count => {
+      if (count > 0) {
+        this.reporteService.word(id).subscribe(response => {
+          const blob = response.body as Blob;
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          const disposition = response.headers.get('Content-Disposition');
+          const match = disposition?.match(/filename=([^;]+)/);
+          a.download = match ? match[1] : `Informe-${id}.docx`;
+          a.click();
+          window.URL.revokeObjectURL(url);
+        });
+      } else {
+        this.mensajeError = 'No existen evaluaciones para generar el reporte';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- check number of evaluations before generating reports
- show toast if there are none

## Testing
- `npm test` *(fails: ng not found)*
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68538c5301b4832b94e11ee6603c0488