### PR TITLE
Handle duplicate users

### DIFF
--- a/backend/controllers/usuario.controller.js
+++ b/backend/controllers/usuario.controller.js
@@ -18,10 +18,18 @@ exports.crearUsuario = async (req, res) => {
   if (err) return res.status(400).json({ message: err });
 
   try {
+    const existe = await UsuarioService.existe(rut);
+    if (existe) {
+      return res.status(400).json({ message: 'Usuario ya registrado' });
+    }
+
     await UsuarioService.crearUsuario(rut, Nombre, Clave, Rol_ID_Rol);
     res.status(201).json({ message: 'Usuario creado correctamente' });
   } catch (error) {
     console.error(error);
+    if (error.code === 'ER_DUP_ENTRY') {
+      return res.status(400).json({ message: 'Usuario ya registrado' });
+    }
     res.status(500).json({ message: 'Error al crear usuario' });
   }
 };

--- a/backend/services/usuario.service.js
+++ b/backend/services/usuario.service.js
@@ -109,3 +109,14 @@ exports.actualizarRol = (id, rolId) => {
     });
   });
 };
+
+// Verificar si un usuario existe por su ID
+exports.existe = (id) => {
+  const sql = `SELECT 1 FROM usuario WHERE ID_Usuario = ? LIMIT 1`;
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [id], (err, results) => {
+      if (err) return reject(err);
+      resolve(results.length > 0);
+    });
+  });
+};

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
@@ -119,9 +119,16 @@ export class DialogUsuarioComponent {
 
     if (this.bloqueado) return;
     this.bloqueado = true;
-    this.usuarioService.crearUsuario(this.usuario).subscribe(() => {
-      this.mensajeExito = 'Usuario creado';
-      setTimeout(() => this.cerrarConExito(), 1500);
+    this.usuarioService.crearUsuario(this.usuario).subscribe({
+      next: () => {
+        this.mensajeExito = 'Usuario creado';
+        setTimeout(() => this.cerrarConExito(), 1500);
+      },
+      error: (err) => {
+        this.bloqueado = false;
+        this.mensajeError = err.error?.message || 'Error al crear usuario';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add an `existe` helper to verify if a user already exists
- check for existing user and duplicate key errors when creating a user
- show backend error messages on the user creation dialog

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a85e5bf0832b980a1bf14ab9aca1