### PR TITLE
Implement user deletion

### DIFF
--- a/backend/controllers/usuario.controller.js
+++ b/backend/controllers/usuario.controller.js
@@ -122,3 +122,15 @@ exports.actualizarRol = async (req, res) => {
     res.status(500).json({ message: 'Error al actualizar rol' });
   }
 };
+
+// Eliminar usuario
+exports.eliminar = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await UsuarioService.eliminar(id);
+    res.json({ message: 'Usuario eliminado' });
+  } catch (error) {
+    console.error('Error al eliminar usuario:', error);
+    res.status(500).json({ message: 'Error al eliminar usuario' });
+  }
+};

--- a/backend/routes/usuario.routes.js
+++ b/backend/routes/usuario.routes.js
@@ -9,6 +9,7 @@ router.get('/profesores', controller.getProfesores);
 router.get('/todos', controller.getTodos);
 router.put('/clave/:id', controller.actualizarClave);
 router.put('/rol/:id', controller.actualizarRol);
+router.delete('/eliminar/:id', controller.eliminar);
 
 
 module.exports = router;

--- a/backend/services/usuario.service.js
+++ b/backend/services/usuario.service.js
@@ -120,3 +120,11 @@ exports.existe = (id) => {
     });
   });
 };
+
+// Eliminar un usuario
+exports.eliminar = (id) => {
+  const sql = `DELETE FROM usuario WHERE ID_Usuario = ?`;
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [id], (err) => (err ? reject(err) : resolve()));
+  });
+};

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.html
@@ -85,6 +85,7 @@
       <i
         class="bi"
         [ngClass]="{
+          'bi-exclamation-triangle-fill text-danger': accionConfirmada === 'eliminar',
           'bi-check-circle-fill': accionConfirmada === 'crear',
           'bi-pencil-fill': accionConfirmada === 'actualizar' || accionConfirmada === 'rol'
         }"
@@ -98,6 +99,7 @@
       <button class="btn btn-success btn-sm text-white" *ngIf="accionConfirmada === 'crear'" (click)="crear()">Sí, crear</button>
       <button class="btn btn-primary btn-sm text-white" *ngIf="accionConfirmada === 'actualizar'" (click)="renovarClave()">Sí, actualizar</button>
       <button class="btn btn-info btn-sm text-white" *ngIf="accionConfirmada === 'rol'" (click)="cambiarRol()">Sí, actualizar</button>
+      <button class="btn btn-danger btn-sm text-white" *ngIf="accionConfirmada === 'eliminar'" (click)="eliminarUsuario()">Sí, eliminar</button>
       <button class="btn btn-outline-secondary btn-sm" (click)="cancelarConfirmacion()">Cancelar</button>
     </div>
   </div>
@@ -138,6 +140,13 @@
   <button class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cancelar</button>
 </div>
 
-<div class="modal-footer" *ngIf="modo === 'ver' || mensajeExito">
+<div class="modal-footer" *ngIf="modo === 'ver' && !mensajeExito && !accionConfirmada">
+  <button class="btn btn-danger" (click)="eliminarUsuario()" [disabled]="bloqueado">
+    <i class="bi bi-trash3-fill me-1"></i> Eliminar
+  </button>
+  <button class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cerrar</button>
+</div>
+
+<div class="modal-footer" *ngIf="mensajeExito">
   <button class="btn btn-secondary" (click)="cancelar()" [disabled]="bloqueado">Cerrar</button>
 </div>

--- a/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
+++ b/src/app/modules/admin/usuarios/dialog-usuario/dialog-usuario.component.ts
@@ -32,7 +32,7 @@ export class DialogUsuarioComponent {
   mensajeExito = '';
   mensajeError = '';
   bloqueado = false;
-  accionConfirmada: 'crear' | 'actualizar' | 'rol' | null = null;
+  accionConfirmada: 'crear' | 'actualizar' | 'rol' | 'eliminar' | null = null;
   private modalCerrado = false;
 
   constructor(
@@ -152,6 +152,27 @@ export class DialogUsuarioComponent {
         this.mensajeExito = 'Rol actualizado';
         setTimeout(() => this.cerrarConExito(), 1500);
       });
+  }
+
+  eliminarUsuario() {
+    if (!this.accionConfirmada) {
+      this.accionConfirmada = 'eliminar';
+      return;
+    }
+
+    if (this.bloqueado) return;
+    this.bloqueado = true;
+    this.usuarioService.eliminar(this.usuario.ID_Usuario).subscribe({
+      next: () => {
+        this.mensajeExito = 'Usuario eliminado';
+        setTimeout(() => this.cerrarConExito(), 1500);
+      },
+      error: () => {
+        this.bloqueado = false;
+        this.mensajeError = 'No se pudo eliminar el usuario';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
+    });
   }
 
   cancelar() {

--- a/src/app/services/usuario.service.ts
+++ b/src/app/services/usuario.service.ts
@@ -38,4 +38,8 @@ export class UsuarioService {
     return this.http.put(`${this.apiUrl}/rol/${id}`, { rolId });
   }
 
+  eliminar(id: string) {
+    return this.http.delete(`${this.apiUrl}/eliminar/${id}`);
+  }
+
 }


### PR DESCRIPTION
## Summary
- add controller, service and route to delete users in backend
- expose delete method in usuario service
- update admin user dialog to allow deleting users

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a9da2668832bbfc45c77fca120d5