### PR TITLE
Add search field to career list

### DIFF
--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.html
@@ -19,6 +19,18 @@
       </h3>
     </div>
 
+    <div class="card mb-4">
+      <div class="card-body">
+        <input
+          type="text"
+          class="form-control"
+          placeholder="Buscar por nombre o jefe..."
+          [(ngModel)]="filtroTexto"
+          (input)="aplicarFiltro()"
+        />
+      </div>
+    </div>
+
     <!-- Tabla -->
     <div class="card shadow-sm border-0">
       <div class="card-body p-0 table-responsive">
@@ -31,7 +43,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr *ngFor="let carrera of carreras" style="cursor: pointer;">
+            <tr *ngFor="let carrera of carrerasFiltradas" style="cursor: pointer;">
               <td>{{ carrera.Nombre }}</td>
               <td>{{ carrera.JefeCarrera }}</td>
               <td class="text-end">

--- a/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
+++ b/src/app/modules/admin/carreras/main-carreras/main-carreras.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { CarreraService } from '../../../../services/carrera.service';
 import { UsuarioService } from '../../../../services/usuario.service';
 import { DialogCarreraComponent } from '../dialog-carrera/dialog-carrera.component';
@@ -12,12 +13,14 @@ import { Carrera, Usuario } from '../../../../models';
   templateUrl: './main-carreras.component.html',
   styleUrls: ['./main-carreras.component.css'],
   standalone: true,
-  imports: [CommonModule, NgbModalModule, SidebarComponent]
+  imports: [CommonModule, FormsModule, NgbModalModule, SidebarComponent]
 })
 export class MainCarrerasComponent implements OnInit {
   carreras: Carrera[] = [];
+  carrerasFiltradas: Carrera[] = [];
   jefes: Usuario[] = [];
   rolUsuario: string = '';
+  filtroTexto: string = '';
 
   constructor(
     private carreraService: CarreraService,
@@ -32,7 +35,18 @@ export class MainCarrerasComponent implements OnInit {
   }
 
   cargarCarreras() {
-    this.carreraService.getCarreras().subscribe(data => this.carreras = data);
+    this.carreraService.getCarreras().subscribe(data => {
+      this.carreras = data;
+      this.aplicarFiltro();
+    });
+  }
+
+  aplicarFiltro() {
+    const texto = this.filtroTexto.toLowerCase();
+    this.carrerasFiltradas = this.carreras.filter(c =>
+      c.Nombre.toLowerCase().includes(texto) ||
+      (c.JefeCarrera ? c.JefeCarrera.toLowerCase().includes(texto) : false)
+    );
   }
 
   cargarJefes() {


### PR DESCRIPTION
## Summary
- allow filtering career list by name or chief
- add text field and filter logic in `main-carreras`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b059d944832b93fcd95df4ea6895