### PR TITLE
Add duplicate check for competencia

### DIFF
--- a/backend/controllers/competencia.controller.js
+++ b/backend/controllers/competencia.controller.js
@@ -15,6 +15,13 @@ exports.getCompetenciaById = async (req, res) => {
 // Crear una nueva competencia
 exports.crearCompetencia = async (req, res) => {
   const { ID_Competencia, Nombre, Descripcion, Tipo } = req.body;
+  if (await CompetenciaService.existeId(ID_Competencia)) {
+    return res.status(400).json({ message: 'El ID de la competencia ya está registrado' });
+  }
+  if (await CompetenciaService.existeNombre(Nombre)) {
+    return res.status(400).json({ message: 'El nombre de la competencia ya está registrado' });
+  }
+
   await CompetenciaService.crear({ ID_Competencia, Nombre, Descripcion, Tipo });
   res.status(201).json({ message: 'Competencia creada con éxito' });
 };
@@ -22,6 +29,10 @@ exports.crearCompetencia = async (req, res) => {
 // Actualizar una competencia existente
 exports.actualizarCompetencia = async (req, res) => {
   const { Nombre, Descripcion, Tipo } = req.body;
+  if (await CompetenciaService.existeNombreOtro(Nombre, req.params.id)) {
+    return res.status(400).json({ message: 'El nombre de la competencia ya está registrado' });
+  }
+
   await CompetenciaService.actualizar(req.params.id, { Nombre, Descripcion, Tipo });
   res.json({ message: 'Competencia actualizada' });
 };

--- a/backend/services/competencia.service.js
+++ b/backend/services/competencia.service.js
@@ -20,6 +20,39 @@ exports.getById = (id) => {
   });
 };
 
+// Verificar si existe una competencia con el ID dado
+exports.existeId = (id) => {
+  const sql = 'SELECT 1 FROM competencia WHERE ID_Competencia = ? LIMIT 1';
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [id], (err, results) => {
+      if (err) return reject(err);
+      resolve(results.length > 0);
+    });
+  });
+};
+
+// Verificar si existe una competencia con el nombre dado
+exports.existeNombre = (nombre) => {
+  const sql = 'SELECT 1 FROM competencia WHERE Nombre = ? LIMIT 1';
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [nombre], (err, results) => {
+      if (err) return reject(err);
+      resolve(results.length > 0);
+    });
+  });
+};
+
+// Verificar si existe una competencia con el nombre dado excluyendo un ID
+exports.existeNombreOtro = (nombre, id) => {
+  const sql = 'SELECT 1 FROM competencia WHERE Nombre = ? AND ID_Competencia <> ? LIMIT 1';
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [nombre, id], (err, results) => {
+      if (err) return reject(err);
+      resolve(results.length > 0);
+    });
+  });
+};
+
 // Crear una nueva competencia
 exports.crear = ({ ID_Competencia, Nombre, Descripcion, Tipo }) => {
   const sql = `

--- a/src/app/modules/competencia-ra/dialog-form-competencia/dialog-form-competencia.component.ts
+++ b/src/app/modules/competencia-ra/dialog-form-competencia/dialog-form-competencia.component.ts
@@ -63,8 +63,17 @@ export class DialogFormCompetenciaComponent implements OnInit {
 
     this.bloqueado = true;
     this.mensajeExito = 'Competencia creada con éxito';
-    this.competenciaService.crear(this.competencia).subscribe(() => {
-      setTimeout(() => this.cerrarConExito(), 1500);
+    this.competenciaService.crear(this.competencia).subscribe({
+      next: () => {
+        setTimeout(() => this.cerrarConExito(), 1500);
+      },
+      error: (err) => {
+        this.bloqueado = false;
+        this.accionConfirmada = null;
+        this.mensajeExito = '';
+        this.mensajeError = err.error?.message || 'Error al crear competencia';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
     });
   }
 
@@ -85,8 +94,17 @@ export class DialogFormCompetenciaComponent implements OnInit {
     this.mensajeExito = 'Competencia actualizada correctamente';
     this.competenciaService
       .actualizar(this.competencia.ID_Competencia, this.competencia)
-      .subscribe(() => {
-        setTimeout(() => this.cerrarConExito(), 1500);
+      .subscribe({
+        next: () => {
+          setTimeout(() => this.cerrarConExito(), 1500);
+        },
+        error: (err) => {
+          this.bloqueado = false;
+          this.accionConfirmada = null;
+          this.mensajeExito = '';
+          this.mensajeError = err.error?.message || 'Error al actualizar competencia';
+          setTimeout(() => (this.mensajeError = ''), 3000);
+        }
       });
   }
 


### PR DESCRIPTION
## Summary
- check for existing competencia id or name when creating or updating
- expose helper functions in backend service
- surface backend errors as toast messages on the frontend

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b8284698832b8f190347e52b2cf0