### PR TITLE
Add RA deletion safeguard

### DIFF
--- a/backend/controllers/ra.controller.js
+++ b/backend/controllers/ra.controller.js
@@ -52,7 +52,15 @@ exports.actualizarRA = async (req, res) => {
 
 exports.eliminarRA = async (req, res) => {
   try {
-    await RaService.eliminar(req.params.id);
+    const id = req.params.id;
+    const tieneIndicadores = await RaService.tieneIndicadores(id);
+    if (tieneIndicadores) {
+      return res.status(400).json({
+        message:
+          'No se puede eliminar el resultado de aprendizaje porque tiene indicadores relacionados',
+      });
+    }
+    await RaService.eliminar(id);
     res.json({ message: 'Resultado de Aprendizaje eliminado' });
   } catch (error) {
     res.status(500).json({ message: 'Error al eliminar RA', error: error.message });

--- a/backend/services/ra.service.js
+++ b/backend/services/ra.service.js
@@ -138,6 +138,17 @@ exports.eliminar = (id) => {
     });
   });
 };
+
+// Comprobar si el RA tiene indicadores asociados
+exports.tieneIndicadores = (id) => {
+  const sql = 'SELECT COUNT(*) AS count FROM indicador WHERE ra_ID_RA = ?';
+  return new Promise((resolve, reject) => {
+    connection.query(sql, [id], (err, results) => {
+      if (err) return reject(err);
+      resolve(results[0].count > 0);
+    });
+  });
+};
 exports.getByAsignatura = (asignaturaId) => {
   const sql = `
     SELECT 

--- a/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
+++ b/src/app/modules/competencia-ra/dialog-ra/dialog-ra.component.ts
@@ -149,9 +149,17 @@ export class DialogRaComponent implements OnInit {
     }
 
     this.bloqueado = true;
-    this.mensajeExito = 'Resultado eliminado';
-    this.raService.eliminar(this.ra.ID_RA!).subscribe(() => {
-      setTimeout(() => this.cerrarConExito(), 1500);
+    this.raService.eliminar(this.ra.ID_RA!).subscribe({
+      next: () => {
+        this.mensajeExito = 'Resultado eliminado';
+        setTimeout(() => this.cerrarConExito(), 1500);
+      },
+      error: (err) => {
+        this.bloqueado = false;
+        this.accionConfirmada = null;
+        this.mensajeError = err.error?.message || 'Error al eliminar RA';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      },
     });
   }
 


### PR DESCRIPTION
## Summary
- prevent deletion of a Resultado de Aprendizaje that has indicators
- show toast error if deletion fails on frontend

## Testing
- `npm test --silent --prefix backend`
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: ng not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853c3e2a314832b8a9256c45b35f92d