### PR TITLE
Handle duplicate student creation

### DIFF
--- a/backend/controllers/estudiante.controller.js
+++ b/backend/controllers/estudiante.controller.js
@@ -18,8 +18,20 @@ exports.getDisponiblesPorAsignatura = async (req, res) => {
 };
 
 exports.crear = async (req, res) => {
-  await EstudianteService.crear(req.body);
-  res.status(201).json({ message: 'Estudiante creado' });
+  try {
+    const existe = await EstudianteService.existe(req.body.ID_Estudiante);
+    if (existe) {
+      return res.status(400).json({ message: 'Estudiante inscrito' });
+    }
+    await EstudianteService.crear(req.body);
+    res.status(201).json({ message: 'Estudiante creado' });
+  } catch (error) {
+    if (error.code === 'ER_DUP_ENTRY') {
+      return res.status(400).json({ message: 'Estudiante inscrito' });
+    }
+    console.error('Error al crear estudiante:', error);
+    res.status(500).json({ message: 'Error al crear estudiante' });
+  }
 };
 
 exports.actualizar = async (req, res) => {
@@ -28,8 +40,16 @@ exports.actualizar = async (req, res) => {
 };
 
 exports.eliminar = async (req, res) => {
-  await EstudianteService.eliminar(req.params.id);
-  res.json({ message: 'Estudiante eliminado' });
+  try {
+    await EstudianteService.eliminar(req.params.id);
+    res.json({ message: 'Estudiante eliminado' });
+  } catch (error) {
+    if (error.code === 'ER_ROW_IS_REFERENCED_2') {
+      return res.status(400).json({ message: 'Estudiante inscrito' });
+    }
+    console.error('Error al eliminar estudiante:', error);
+    res.status(500).json({ message: 'Error al eliminar estudiante' });
+  }
 };
 
 exports.cargarCSV = async (req, res) => {

--- a/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
+++ b/src/app/modules/admin/asignaturas/dialog-form-estudiante/dialog-form-estudiante.component.ts
@@ -74,8 +74,16 @@ export class DialogFormEstudianteComponent implements OnInit {
 
     this.bloqueado = true;
     this.mensajeExito = 'Estudiante creado con éxito';
-    this.estudianteService.crear(this.estudiante).subscribe(() => {
-      setTimeout(() => this.cerrarConExito(), 1500);
+    this.estudianteService.crear(this.estudiante).subscribe({
+      next: () => {
+        setTimeout(() => this.cerrarConExito(), 1500);
+      },
+      error: (err) => {
+        this.bloqueado = false;
+        this.mensajeExito = '';
+        this.mensajeError = err.error?.message || 'Error al crear estudiante';
+        setTimeout(() => (this.mensajeError = ''), 3000);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- prevent duplicate student creation in the backend
- return a clear error when deleting students with existing inscriptions
- show duplicate error in student creation form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c73cc450832b8389b34523455d6e