### PR TITLE
feat: show ideal score in rubric evaluation

### DIFF
--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.html
@@ -48,7 +48,8 @@
   </div>
 
   <div class="mt-3 text-end">
-    <strong class="me-3">Puntaje Total: {{ calcularTotal() }}</strong>
+    <strong class="me-3">Puntaje Obtenido: {{ calcularTotal() }}</strong>
+    <strong class="me-3">Puntaje Ideal: {{ calcularPuntajeIdeal() }}</strong>
     <span class="badge bg-primary">Nota: {{ calcularNota() }}</span>
   </div>
 

--- a/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
+++ b/src/app/modules/profesor/evaluaciones/dialog-rubrica-evaluacion/dialog-rubrica-evaluacion.component.ts
@@ -94,11 +94,15 @@ export class DialogRubricaEvaluacionComponent implements OnInit {
     return Object.values(this.puntajes).reduce((a, b) => a + (b || 0), 0);
   }
 
-  calcularNota(): number {
-    const totalMax = this.indicadores.reduce(
+  calcularPuntajeIdeal(): number {
+    return this.indicadores.reduce(
       (acc, ind) => acc + ind.Puntaje_Max,
       0
     );
+  }
+
+  calcularNota(): number {
+    const totalMax = this.calcularPuntajeIdeal();
     if (totalMax === 0) return 0;
     return Math.round((this.calcularTotal() / totalMax) * 100);
   }


### PR DESCRIPTION
## Summary
- calculate total maximum score across indicators
- display obtained and ideal scores in rubric evaluation modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68910a26e834832ba47f403388722d15