### PR TITLE
Remove bar charts and enhance pie charts

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -1,11 +1,7 @@
 const connection = require('../db/connection');
 const fs = require('fs');
 const path = require('path');
-const {
-  generarGraficoBarras,
-  generarGraficoLineas,
-  generarGraficoTorta,
-} = require('../utils/grafico');
+const { generarGraficoLineas, generarGraficoTorta } = require('../utils/grafico');
 const {
   crearIntroduccion,
   analizarCriterio,
@@ -394,25 +390,19 @@ exports.generarInforme = async asignaturaId => {
 
   const graficosInstancias = {};
   for (const [num, inst] of Object.entries(instancias)) {
-    const barras = [];
     const tortas = [];
     for (const [idx, c] of inst.criterios.entries()) {
-      const barra = await generarGraficoBarras(
-        [c.indicador],
-        [Number(c.porcentaje) || 0],
-        `instancia_${num}_${idx}.png`
-      );
-      barras.push(barra);
       const labels = (c.niveles || []).map(n => n.nombre);
       const valores = (c.niveles || []).map(n => n.porcentaje);
       const torta = await generarGraficoTorta(
         labels,
         valores,
-        `instancia_${num}_${idx}_pie.png`
+        `instancia_${num}_${idx}_pie.png`,
+        c.indicador
       );
       tortas.push(torta);
     }
-    graficosInstancias[num] = { barras, tortas };
+    graficosInstancias[num] = { tortas };
   }
 
   const resumenIndicadores = [...datos].sort((a, b) => a.instancia - b.instancia);
@@ -446,7 +436,6 @@ exports.generarInforme = async asignaturaId => {
   if (docx.length) fs.writeFileSync(path.join(outDir, `${base}.docx`), docx);
   const archivosGraficos = [compPath];
   Object.values(graficosInstancias).forEach(obj => {
-    if (obj.barras) archivosGraficos.push(...obj.barras);
     if (obj.tortas) archivosGraficos.push(...obj.tortas);
   });
   archivosGraficos.forEach(p => {

--- a/backend/utils/grafico.js
+++ b/backend/utils/grafico.js
@@ -117,8 +117,21 @@ async function generarGraficoBarras(labels, datos, nombreArchivo = 'grafico.png'
   return filePath;
 }
 
-async function generarGraficoTorta(labels, datos, nombreArchivo = 'torta.png') {
+async function generarGraficoTorta(
+  labels,
+  datos,
+  nombreArchivo = 'torta.png',
+  titulo = ''
+) {
   if (!chartJSNodeCanvas) return null;
+  const colors = [
+    'rgba(33, 150, 243, 0.7)',
+    'rgba(76, 175, 80, 0.7)',
+    'rgba(255, 193, 7, 0.7)',
+    'rgba(244, 67, 54, 0.7)',
+    'rgba(156, 39, 176, 0.7)',
+    'rgba(158, 158, 158, 0.7)',
+  ];
   const config = {
     type: 'pie',
     data: {
@@ -126,22 +139,13 @@ async function generarGraficoTorta(labels, datos, nombreArchivo = 'torta.png') {
       datasets: [
         {
           data: datos,
-          backgroundColor: labels.map((_, i) => {
-            const colors = [
-              'rgba(75, 192, 192, 0.6)',
-              'rgba(54, 162, 235, 0.6)',
-              'rgba(255, 205, 86, 0.6)',
-              'rgba(255, 99, 132, 0.6)',
-              'rgba(153, 102, 255, 0.6)',
-              'rgba(201, 203, 207, 0.6)',
-            ];
-            return colors[i % colors.length];
-          }),
+          backgroundColor: labels.map((_, i) => colors[i % colors.length]),
         },
       ],
     },
     options: {
       plugins: {
+        title: { display: !!titulo, text: titulo },
         datalabels: {
           color: '#000000',
           formatter: (val, ctx) => {

--- a/backend/utils/reportGenerator.js
+++ b/backend/utils/reportGenerator.js
@@ -890,16 +890,14 @@ exports.generarPDFCompleto = contenido => {
         doc.moveDown(0.5);
         // B. Desglose por indicador
         generarBloqueDesgloseIndicadoresPDF(doc, inst);
-        // C. Gráficos de barras por instancia
         const grafObj = contenido.graficos && contenido.graficos[num];
-        generarGraficoDesempenoPDF(doc, grafObj && grafObj.barras);
         generarTablaCriteriosPorIndicadorPDF(doc, inst);
         generarGraficoDesempenoPDF(doc, grafObj && grafObj.tortas);
-        // D. Conclusiones de instancia
+        // C. Conclusiones de instancia
         generarConclusionPDF(doc, inst);
-        // E. Recomendaciones generales de instancia
+        // D. Recomendaciones generales de instancia
         generarRecomendacionesPDF(doc, inst);
-        // F. Tabla de desempeño por criterio (rúbrica)
+        // E. Tabla de desempeño por criterio (rúbrica)
         doc.fontSize(14).text('Promedio por Criterio', { underline: true });
         doc.moveDown(0.5);
         generarTablaPromediosPorCriterioPDF(doc, inst);
@@ -910,11 +908,11 @@ exports.generarPDFCompleto = contenido => {
         //   drawRATablePDF(doc, inst.raResumen);
         //   generarConclusionRAPDF(doc, inst);
         // }
-        // G. Tabla de cumplimiento por competencia
+        // F. Tabla de cumplimiento por competencia
         generarTablaCompetenciasInstanciaPDF(doc, inst);
-        // H. Análisis por competencia
+        // G. Análisis por competencia
         generarAnalisisCompetenciasPDF(doc, inst);
-        // I. Recomendaciones por competencia
+        // H. Recomendaciones por competencia
         generarRecomendacionesCompetenciasPDF(doc, inst);
       });
 
@@ -1021,19 +1019,10 @@ exports.generarDOCXCompleto = async contenido => {
       );
       // B. Desglose por indicador
       instanciasParagraphs.push(...generarBloqueDesgloseIndicadoresDOCX(inst));
-      // C. Gráficos de barras por instancia
-      const grafObj = (contenido.graficos && contenido.graficos[num]) || {};
-      (grafObj.barras || []).forEach((p, idx) => {
-        const graf = generarGraficoDesempenoDOCX(
-          [inst.criterios[idx].indicador],
-          [inst.criterios[idx].porcentaje],
-          p
-        );
-        if (graf) instanciasParagraphs.push(graf);
-      });
-      // D. Tabla de distribución de niveles por criterio
+      // C. Tabla de distribución de niveles por criterio
       instanciasParagraphs.push(generarTablaCriteriosPorIndicadorDOCX(inst));
-      // E. Gráficos de torta por instancia
+      // D. Gráficos de torta por instancia
+      const grafObj = (contenido.graficos && contenido.graficos[num]) || {};
       (grafObj.tortas || []).forEach((p, idx) => {
         const graf = generarGraficoDesempenoDOCX(
           [inst.criterios[idx].indicador],


### PR DESCRIPTION
## Summary
- drop generation of bar charts from report pipeline
- update pie charts with new color palette and indicator titles
- adjust report generator to include only pie charts

## Testing
- `npm test` (backend)
- `npm test -- --watch=false` (fails: ng not found)
- `npm install` (fails: ERESOLVE could not resolve)


------
https://chatgpt.com/codex/tasks/task_e_68910df2a2a0832b8db4d1693dbae259