### PR TITLE
Actualizar label de núcleo temático a Item en CRUD de contenidos

### DIFF
--- a/src/app/modules/rubricas/dialog-contenido/dialog-contenido.component.html
+++ b/src/app/modules/rubricas/dialog-contenido/dialog-contenido.component.html
@@ -19,7 +19,7 @@
       <table class="table table-hover mb-0 align-middle text-center">
         <thead class="table-light">
           <tr>
-            <th class="text-start">Núcleo Temático</th>
+            <th class="text-start">Item</th>
             <th class="text-start">Descripción</th>
             <th>Horas</th>
             <th>Acciones</th>

--- a/src/app/modules/rubricas/dialog-form-contenido/dialog-form-contenido.component.html
+++ b/src/app/modules/rubricas/dialog-form-contenido/dialog-form-contenido.component.html
@@ -15,7 +15,7 @@
 <div class="modal-body position-relative">
   <form *ngIf="modo !== 'ver'">
     <div class="mb-3">
-      <label class="form-label">Núcleo Temático</label>
+      <label class="form-label">Item</label>
       <input
         type="text"
         class="form-control"
@@ -78,7 +78,7 @@
 
   <!-- Vista solo lectura -->
   <div *ngIf="modo === 'ver'">
-    <p><strong>Núcleo Temático:</strong> {{ contenido.Nucleo_Tematico }}</p>
+    <p><strong>Item:</strong> {{ contenido.Nucleo_Tematico }}</p>
     <p><strong>Descripción:</strong> {{ contenido.Descripcion }}</p>
     <p><strong>Horas:</strong> {{ contenido.Horas }}</p>
   </div>


### PR DESCRIPTION
## Summary
- Cambia textos de "Núcleo Temático" a "Item" en el formulario y vista de contenidos
- Ajusta encabezado del grid de contenidos para mostrar "Item"

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: sh: 1: ng: not found)*
- `npm ci` *(fails: ERESOLVE could not resolve dependencies)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892e9372de4832b82335d4217b51368