### PR TITLE
Ajusta cálculo de porcentaje sobre el promedio

### DIFF
--- a/backend/services/informe.service.js
+++ b/backend/services/informe.service.js
@@ -44,7 +44,7 @@ async function obtenerDatosIndicadores(asignaturaId) {
         MIN(a.Obtenido) AS minimo,
         ROUND(AVG(a.Obtenido), 1) AS promedio,
         ROUND(
-          SUM(a.Obtenido > (
+          SUM(a.Obtenido >= (
             SELECT AVG(Obtenido)
             FROM aplicacion
             WHERE indicador_ID_Indicador = i.ID_Indicador


### PR DESCRIPTION
## Resumen
- Cuenta a estudiantes con puntaje igual al promedio dentro del porcentaje sobre el promedio

## Testing
- `node backend/utils/__tests__/resumenCompetencias.test.js`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: ng: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893ace5feb8832b946eb7faffd187b1